### PR TITLE
chore: enforce phase-0 Python lint hygiene

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = tab
+indent_size = 4
+
+[*.{md,yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+# Tabs are the repository standard for Python indentation.
 ignore = E123,E124,E126,E127,E128,E223,W191,W503
 max-line-length = 120
 max-complexity = 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: python-tabs
+        name: Enforce tabs for Python indentation
+        entry: python3 scripts/check_python_tabs.py
+        language: system
+        types: [python]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # mctutil
 General tools for working with MicroCT data at PSU
+
+## Development hygiene
+
+- Python indentation uses tabs in this repository.
+- No autoformatter is configured at this time.
+- Linting is enforced with `flake8` and the pre-commit hooks in `.pre-commit-config.yaml`.

--- a/scripts/check_python_tabs.py
+++ b/scripts/check_python_tabs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Reject Python files whose leading indentation starts with spaces."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+LEADING_WS = re.compile(r'^(?P<ws>[ \t]+)(?=\S)')
+
+
+def iter_python_files(paths: list[str]) -> list[Path]:
+	if paths:
+		return [Path(path) for path in paths if path.endswith('.py')]
+
+	return sorted(Path('.').rglob('*.py'))
+
+
+def main(argv: list[str] | None = None) -> int:
+	parser = argparse.ArgumentParser(
+		description='Fail when Python files use spaces for leading indentation.',
+	)
+	parser.add_argument('paths', nargs='*')
+	args = parser.parse_args(argv)
+
+	violations: list[str] = []
+	for path in iter_python_files(args.paths):
+		if not path.is_file():
+			continue
+
+		for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+			match = LEADING_WS.match(line)
+			if not match:
+				continue
+
+			whitespace = match.group('ws')
+			if whitespace.startswith(' ') or ' \t' in whitespace:
+				violations.append(f'{path}:{line_number}: leading indentation must use tabs')
+
+	if violations:
+		print('\n'.join(violations), file=sys.stderr)
+		return 1
+
+	return 0
+
+
+if __name__ == '__main__':
+	raise SystemExit(main())

--- a/transform/gz_strip.py
+++ b/transform/gz_strip.py
@@ -6,9 +6,9 @@ import click
 @click.command()
 @click.argument("root_path", type=click.Path(exists=True))
 def stripgz(root_path):
-    for fname in Path(root_path).glob("**/*.gz"):
-        fname.rename(fname.with_suffix(''))
+	for fname in Path(root_path).glob("**/*.gz"):
+		fname.rename(fname.with_suffix(''))
 
 
 if __name__ == '__main__':
-    stripgz()
+	stripgz()


### PR DESCRIPTION
## Summary
- document tabs as the Python indentation standard for this repository
- add a non-autoformatting pre-commit setup using flake8 plus a custom indentation checker
- normalize the only space-indented Python file currently in the tree

## Verification
- `python3 scripts/check_python_tabs.py`
- `python3 -m py_compile scripts/check_python_tabs.py transform/gz_strip.py transform/upload.py transport/s3upload.py`
- `git diff --check`

## Notes
- Intentionally does **not** add `ruff`, `black`, or any other autoformatter.
- Related: #11
