### PR TITLE
fix: land phase 1 script repairs

### DIFF
--- a/ng/layer_extract.py
+++ b/ng/layer_extract.py
@@ -11,7 +11,7 @@ import click
 @click.option("--json-result", "-r", type=click.Path(path_type=Path, exists=False),
 				required=True, help="Neuroglancer JSON file to write to.")
 @click.argument("layers", type=str, nargs=-1)
-def layer_copy(json_file: Path, json_result: Path, layers: str):
+def layer_extract(json_file: Path, json_result: Path, layers: str):
 	""" Extract layers contained in a neuroglancer json file into a new file.
 
 		Example run:
@@ -39,4 +39,4 @@ def layer_copy(json_file: Path, json_result: Path, layers: str):
 
 
 if __name__ == "__main__":
-	layer_copy()
+	layer_extract()

--- a/ng/layer_tag.py
+++ b/ng/layer_tag.py
@@ -79,7 +79,7 @@ def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: 
 				# Generate an intensity that's not a repeat.
 				t_layer = replace(t_layer, intensity=next(intensity_gen))
 				while t_layer.intensity in preset_intensities:
-					replace(t_layer, intensity=next(intensity_gen))
+					t_layer = replace(t_layer, intensity=next(intensity_gen))
 
 			if t_layer.radius == -1:
 				# Update with default intensity.

--- a/ng/point_shift.py
+++ b/ng/point_shift.py
@@ -31,7 +31,7 @@ COORDINATES = Coordinates()
 				required=True, help="Neuroglancer JSON file to write shifted annotations.")
 @click.option("--shift-dimensions", "-s", type=COORDINATES, required=True,
 				help="Amount to shift all annotations, in 'x,y,z' format.")
-def point_merge(json_file: Path, json_result: Path, shift_dimensions: Coord):
+def point_shift(json_file: Path, json_result: Path, shift_dimensions: Coord):
 	""" Shift all annotations in a given file in 3 dimensions.
 
 		Example run:
@@ -57,4 +57,4 @@ def point_merge(json_file: Path, json_result: Path, shift_dimensions: Coord):
 
 
 if __name__ == "__main__":
-	point_merge()
+	point_shift()

--- a/ng/point_sort.py
+++ b/ng/point_sort.py
@@ -41,7 +41,7 @@ ANNOTATION_PAIR = AnnotationPairParameter()
 				required=True, help="Neuroglancer JSON file to write sorted annotation(s).")
 @click.option("--axis", "-a", type=click.INT, required=True, help="Axis (0-2 for X/Y/Z) to sort on.")
 @click.argument("source_annotations", type=ANNOTATION_PAIR, nargs=-1)
-def point_merge(json_file: Path, json_result: Path, axis: int, source_annotations: tuple):
+def point_sort(json_file: Path, json_result: Path, axis: int, source_annotations: tuple):
 	""" Sort one or more annotation layers in a JSON file, according to one (X/Y/Z) dimension.
 		Each SOURCE_ANNOTATION should be a name, followed by a colon and then whether to
 		sort the points in FORWARD or BACKWARD order, e.g. R2-Root:FORWARD.
@@ -74,4 +74,4 @@ def point_merge(json_file: Path, json_result: Path, axis: int, source_annotation
 
 
 if __name__ == "__main__":
-	point_merge()
+	point_sort()

--- a/parsing/scanlog_fetch.py
+++ b/parsing/scanlog_fetch.py
@@ -7,7 +7,7 @@ import click
 @click.command()
 @click.argument("root_dir", nargs=-1, type=click.Path())
 def scanlog_fetch(root_dir):
-	Path("logs").mkdir(exists_ok=True)
+	Path("logs").mkdir(exist_ok=True)
 	for dir_name in root_dir:
 		for fullpath in Path(dir_name).rglob("scanlog.txt"):
 			software_trigger_scans = ["_post", "_pre", "_uncrop", "_crop", "_focus", "_step"]

--- a/tests/test_click_smoke.py
+++ b/tests/test_click_smoke.py
@@ -19,13 +19,13 @@ CASES = [
 	CommandCase("mem/clean.py", "memclean", ("mark", "--help")),
 	CommandCase("ng/change_color.py", "change_color"),
 	CommandCase("ng/layer_copy.py", "layer_copy"),
-	CommandCase("ng/layer_extract.py", "layer_copy"),
+	CommandCase("ng/layer_extract.py", "layer_extract"),
 	CommandCase("ng/layer_tag.py", "layer_tag"),
 	CommandCase("ng/layer_urlshift.py", "layer_urlshift"),
 	CommandCase("ng/point_add.py", "point_add"),
 	CommandCase("ng/point_merge.py", "point_merge"),
-	CommandCase("ng/point_shift.py", "point_merge"),
-	CommandCase("ng/point_sort.py", "point_merge"),
+	CommandCase("ng/point_shift.py", "point_shift"),
+	CommandCase("ng/point_sort.py", "point_sort"),
 	CommandCase("ng/position_copy.py", "position_copy"),
 	CommandCase("ng/shift_angle.py", "shift_angle"),
 	CommandCase("parsing/pull_config.py", "get_conf"),
@@ -40,13 +40,7 @@ CASES = [
 	CommandCase("transform/fix_name.py", "fix_names"),
 	CommandCase("transform/gz_strip.py", "stripgz"),
 	CommandCase("transform/hdf_convert.py", "hdf_convert"),
-	pytest.param(
-		CommandCase("transform/mesh.py", "mesh"),
-		marks=pytest.mark.xfail(
-			reason="Known Phase 1 bug: @click.commmand typo",
-			strict=True,
-		),
-	),
+	CommandCase("transform/mesh.py", "mesh"),
 	CommandCase("transform/mesh_ig.py", "mesh_ig"),
 	CommandCase("transform/multitrim.py", "trim"),
 	CommandCase("transform/ng.py", "neuroglance"),
@@ -74,7 +68,6 @@ def test_click_help_smoke(load_module, case: CommandCase):
 	assert result.exit_code == 0, result.output
 
 
-@pytest.mark.xfail(reason="Known Phase 1 bug: -s short-option collision", strict=True)
 def test_upload_short_options_are_unique(load_module):
 	module = load_module("transform/upload.py")
 	short_opts = [

--- a/tests/test_phase1_regressions.py
+++ b/tests/test_phase1_regressions.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from pathlib import Path
+import types
+
+import click
+import numpy as np
+import pytest
+import tifffile
+from click.testing import CliRunner
+
+
+class _StopAfterDimensions(RuntimeError):
+	pass
+
+
+class _StopSharedNP:
+	def __init__(self, *_args, **_kwargs):
+		pass
+
+	def __enter__(self):
+		raise _StopAfterDimensions()
+
+	def __exit__(self, exc_type, exc, tb):
+		return False
+
+
+class _FakeMem:
+	def __init__(self, array):
+		self.array = array
+
+	def __enter__(self):
+		return self.array
+
+	def __exit__(self, exc_type, exc, tb):
+		return False
+
+
+def test_scanlog_fetch_creates_logs_dir_and_copies_valid_scanlogs(load_module, monkeypatch, tmp_path):
+	module = load_module("parsing/scanlog_fetch.py")
+	root_dir = tmp_path / "scan"
+	scan_dir = root_dir / "sample"
+	scan_dir.mkdir(parents=True)
+	(scan_dir / "scanlog.txt").write_text("x" * 94)
+	monkeypatch.chdir(tmp_path)
+
+	result = CliRunner().invoke(module.scanlog_fetch, [str(root_dir)])
+
+	assert result.exit_code == 0, result.output
+	copied = tmp_path / "logs" / "sample_scanlog.txt"
+	assert copied.exists()
+	assert copied.read_text() == "x" * 94
+
+
+def test_normalize_processes_option_is_an_int_param(load_module):
+	module = load_module("transform/normalize.py")
+	process_option = next(param for param in module.norm.params if param.name == "processes")
+	assert isinstance(process_option.type, click.types.IntParamType)
+
+
+def test_df_write_tiff_uses_source_title_for_output_name(load_module, monkeypatch, tmp_path):
+	module = load_module("transform/df_write_tiff.py")
+	source_path = tmp_path / "source.ors"
+	source_path.write_text("placeholder")
+	output_dir = tmp_path / "out"
+	output_dir.mkdir()
+	written = {}
+
+	class DummyList:
+		def loadFromFileFiltered(self, *_args, **_kwargs):
+			return None
+
+	class DummySource:
+		def getTitle(self):
+			return "roi-title"
+
+		def getAsNDArray(self, *_args):
+			return np.arange(4, dtype=np.uint8).reshape(2, 2)
+
+	source = DummySource()
+	monkeypatch.setattr(module, "List", DummyList)
+	monkeypatch.setattr(module, "Managed", types.SimpleNamespace(
+		getAllObjectsOfClassAndTitle=staticmethod(lambda *_args, **_kwargs: [source]),
+	))
+	monkeypatch.setattr(module, "orsObj", lambda *_args, **_kwargs: source)
+	monkeypatch.setattr(module.tf, "imwrite", lambda path, data: written.update(path=Path(path), data=data.copy()))
+
+	module.df_write_tiff.callback(source_path, None, None, "dummy-id", output_dir)
+
+	assert written["path"].name == "roi-title.tif"
+	assert written["path"].parent == output_dir
+	assert written["data"].shape == (2, 2)
+
+
+def test_hdf_convert_finds_raw_subdir_with_posix_glob(load_module, tmp_path):
+	module = load_module("transform/hdf_convert.py")
+	folder = tmp_path / "proj"
+	raw_dir = folder / "raw"
+	raw_dir.mkdir(parents=True)
+	(raw_dir / "slice.hdf").write_text("stub")
+
+	paths = module.get_image_paths(folder)
+
+	assert paths == [raw_dir / "slice.hdf"]
+
+
+def test_s3upload_does_not_require_client_close(load_module, monkeypatch, tmp_path):
+	module = load_module("transport/s3upload.py")
+	source_dir = tmp_path / "input"
+	source_dir.mkdir()
+	client_calls = []
+
+	class DummyClient:
+		def put_object(self, **kwargs):
+			client_calls.append(kwargs)
+
+	class DummySession:
+		def client(self, *_args, **_kwargs):
+			return DummyClient()
+
+	monkeypatch.setattr(module, "session", DummySession())
+	monkeypatch.setattr(module, "upload_folder_to_s3_parallel", lambda *_args, **_kwargs: None)
+
+	module.s3upload.callback(Path("prefix"), "bucket", 4, False, source_dir, Path("target"))
+
+	assert client_calls == [{"Bucket": "bucket", "Key": "prefix/target/"}]
+
+
+def test_layer_tag_retries_generated_intensity_until_unique(load_module, monkeypatch, tmp_path):
+	module = load_module("ng/layer_tag.py")
+	source = {
+		"layers": [
+			{"name": "existing", "type": "annotation", "annotations": []},
+			{"name": "fresh", "type": "annotation", "annotations": []},
+		],
+	}
+	src = tmp_path / "input.json"
+	dst = tmp_path / "output.json"
+	src.write_text(__import__("json").dumps(source))
+	monkeypatch.setattr(module.np, "nditer", lambda *_args, **_kwargs: iter([5, 7]))
+
+	result = CliRunner().invoke(
+		module.layer_tag,
+		[
+			"-j", str(src),
+			"-r", str(dst),
+			"existing:5",
+			"fresh",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	output = __import__("json").loads(dst.read_text())
+	layer_names = {layer["name"] for layer in output["layers"]}
+	assert "existing ID5r30" in layer_names
+	assert "fresh ID7r30" in layer_names
+
+
+def test_image_bounds_returns_min_and_max(load_module):
+	module = load_module("transform/sino_preproc.py")
+	bounds = module.image_bounds(_FakeMem(np.array([[3, 8], [1, 5]], dtype=np.float32)))
+	assert np.array_equal(bounds, np.array([1, 8], dtype=np.float32))
+
+
+def test_multitrim_applies_vertical_to_axis_zero_and_horizontal_to_axis_one(load_module, monkeypatch, tmp_path):
+	module = load_module("transform/multitrim.py")
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	output_dir.mkdir()
+	tifffile.imwrite(input_dir / "slice.tif", np.arange(16, dtype=np.uint8).reshape(4, 4))
+	captured = {}
+
+	monkeypatch.setattr(module, "SharedNP", _StopSharedNP)
+	monkeypatch.setattr(module.log, "start", lambda: None)
+	monkeypatch.setattr(module.log, "log", lambda stage, message, *args: captured.setdefault(stage, message))
+	monkeypatch.setattr(module.psutil, "cpu_count", lambda: 1)
+
+	with pytest.raises(_StopAfterDimensions):
+		module.trim.callback(str(input_dir), str(output_dir), 0.25, 0.5, module.cli.NUMPYTYPE.convert("uint8", None, None))
+
+	assert captured["Dimensions"] == "(4, 4)-(slice(1, 3, None), slice(2, 2, None))"
+
+
+def test_layer_urlshift_updates_sources_in_place(load_module, tmp_path):
+	module = load_module("ng/layer_urlshift.py")
+	source = {
+		"layers": [
+			{"name": "img", "type": "image", "source": "bucket|rest"},
+			{"name": "seg", "type": "segmentation", "source": {"url": "bucket-two|rest"}},
+		],
+	}
+	src = tmp_path / "input.json"
+	dst = tmp_path / "output.json"
+	src.write_text(__import__("json").dumps(source))
+
+	result = CliRunner().invoke(module.layer_urlshift, ["-j", str(src), "-r", str(dst)])
+
+	assert result.exit_code == 0, result.output
+	output = __import__("json").loads(dst.read_text())
+	assert output["layers"][0]["source"] == "precomputed://bucket"
+	assert output["layers"][1]["source"]["url"] == "precomputed://bucket-two"

--- a/transform/df_write_tiff.py
+++ b/transform/df_write_tiff.py
@@ -3,10 +3,14 @@ from pathlib import Path
 import sys
 
 
+def _env_path(name: str, default: str) -> Path:
+	return Path(os.environ.get(name, default))
+
+
 def set_df_environment():
-	df_dir = Path("C:\\Program Files\\Dragonfly")
-	ors_dir = Path("C:\\ProgramData\\ORS\\Dragonfly2024.1")
-	user_dir = Path("C:\\Users\\dnorthover\\AppData\\Local\\ORS\\Dragonfly2024.1")
+	df_dir = _env_path("DRAGONFLY_DIR", "C:\\Program Files\\Dragonfly")
+	ors_dir = _env_path("DRAGONFLY_ORS_DIR", "C:\\ProgramData\\ORS\\Dragonfly2024.1")
+	user_dir = _env_path("DRAGONFLY_USER_DIR", "C:\\Users\\dnorthover\\AppData\\Local\\ORS\\Dragonfly2024.1")
 	ana_dir = df_dir.joinpath("Anaconda3")
 
 	os.environ["orspath"] = str(df_dir)
@@ -49,7 +53,7 @@ def df_write_tiff(df_source, df_object, df_title, df_id, outputdir):
 	else:
 		source = orsObj(df_id)
 
-	tf.imwrite(outputdir.joinpath(f"{roi.getTitle()}.tif"), source.getAsNDArray(0))
+	tf.imwrite(outputdir.joinpath(f"{source.getTitle()}.tif"), source.getAsNDArray(0))
 
 
 if __name__ == "__main__":

--- a/transform/hdf_convert.py
+++ b/transform/hdf_convert.py
@@ -16,7 +16,7 @@ def get_image_paths(folder: Path):
 		:param folder: Base Path containing raw folder.
 		:return: Sorted list of HDF files.
 	"""
-	return sorted(folder.glob('raw\\*.hdf'))
+	return sorted(folder.glob('raw/*.hdf'))
 
 
 def image_conv(image_path: Path, target_dir: Path):

--- a/transform/mesh.py
+++ b/transform/mesh.py
@@ -11,7 +11,7 @@ import igneous.task_creation as tc
 # layer_path = 'precomputed://s3://3d.fish/assets/precomputed_repository/B2_daphnia/AAA399/AAA399_seg_out/'
 
 
-@click.commmand
+@click.command()
 @click.option("-p", "--proj-dir", type=click.Path(file_okay=False), required=True, help="Path of input data.")
 @click.option("-l", "--layer-path", type=click.STRING, required=True, help="Path of Layer data, including remote URLs.")
 def mesh(proj_dir, layer_path):

--- a/transform/multitrim.py
+++ b/transform/multitrim.py
@@ -59,8 +59,8 @@ def trim(data_dir, output_dir, vertical_trim, horizontal_trim, out_dtype):
 	with tf.TiffFile(inputs[0]) as tif:
 		mem_shape = ProjOrder(processes, tif.pages[0].shape[0], tif.pages[0].shape[1])
 		dim = tif.pages[0].shape
-		out_dim = np.s_[int(dim[0] * horizontal_trim):int(dim[0] * (1 - horizontal_trim)),
-						int(dim[1] * vertical_trim):int(dim[1] * (1 - vertical_trim))]
+		out_dim = np.s_[int(dim[0] * vertical_trim):int(dim[0] * (1 - vertical_trim)),
+						int(dim[1] * horizontal_trim):int(dim[1] * (1 - horizontal_trim))]
 		log.log("Dimensions", f"{dim}-{out_dim}")
 
 	with SharedNP('Normalize_Mem', np.float32, mem_shape, create=True) as norm_mem:

--- a/transform/normalize.py
+++ b/transform/normalize.py
@@ -74,7 +74,7 @@ def mem_write(mem: SharedNP, path: PathLike, i, dtype):
 @click.option('-d', '--data-dir', type=click.Path(exists=True), help='Input path for noisy dataset')
 @click.option('-o', '--output-dir', type=click.Path(),
 				help='Output path for cleaned images', default='data/clean/')
-@click.option('-p', '--processes', type=click.Path(), default=psutil.cpu_count(),
+@click.option('-p', '--processes', type=click.INT, default=psutil.cpu_count(),
 				help='Process Count (for simulatenous images)')
 def norm(normalize_over, data_dir, output_dir, processes):
 	log.start()

--- a/transform/sino_preproc.py
+++ b/transform/sino_preproc.py
@@ -187,7 +187,7 @@ def sino_write(sino_mem: SharedNP, path: PathLike, i, out_type: cli.NumpyCLI = N
 
 def image_bounds(sino_mem: SharedNP):
 	with sino_mem as sino:
-		np.array([np.min(sino), np.max(sino)])
+		return np.array([np.min(sino), np.max(sino)])
 
 
 def minmaxscale(sino_mem, i, minval=None, maxval=None):
@@ -257,11 +257,11 @@ def sino_convert(input_dir: Path, output_dir: Path, process_count: int, min_val:
 
 				log.log("Files Read", f"Window {window}; Shape {sino_shape}")
 
-				with Pool(process_count) as pool:
-					bounds += pool.map(image_bounds, sino_mem)
+				bounds.append(image_bounds(sino_mem))
 
 				log.log("Bounds Calculated", f"{window}", log.DEBUG.TIME)
 
+		bounds = np.asarray(bounds)
 		min_val = np.min(bounds[:, 0])
 		max_val = np.max(bounds[:, 1])
 		log.log("Final Bounds Calculated", f"{min_val} : {max_val}", log.DEBUG.TIME)

--- a/transform/upload.py
+++ b/transform/upload.py
@@ -22,7 +22,7 @@ def upload_file_to_s3(session, file_path, key, bucket_name, content_encoding):
 @click.option("-s", "--source-folder", type=click.Path(), required=True, help="Data folder to upload.")
 @click.option("-t", "--target-folder", type=click.Path(readable=False), required=True, help="Target folder name on S3")
 @click.option("-b", "--bucket", type=click.STRING, required=True, help="Name of S3 bucket to upload to.")
-@click.option("-s", "--secret-json", type=click.File(), required=True,
+@click.option("-k", "--secret-json", type=click.File(), required=True,
 				help="Location of json file to load AWS credentials from.")
 @click.option("-p", "--process-count", type=click.INT, default=60, show_default=True, help="Simultaneous Uploads.")
 def upload(source_folder, target_folder, bucket, secret_json, process_count):

--- a/transport/s3upload.py
+++ b/transport/s3upload.py
@@ -71,7 +71,6 @@ def s3upload(bucket_prefix, bucket_name, process_count, mesh, source_folder, tar
 
 	s3 = session.client('s3')
 	s3.put_object(Bucket=bucket_name, Key=f"{target_full}/")
-	s3.close()
 
 	upload_folder_to_s3_parallel(source_folder, target_full, bucket_name, num_processes=process_count)
 


### PR DESCRIPTION
## Summary
- apply the Phase 1 broken-script repairs called out in `REFACTOR_PLAN.md`
- remove the Phase 0 smoke-test xfails by fixing the mesh decorator typo and upload short-flag collision
- add focused regression tests for the fixed command and logic bugs

## Included fixes
- `transform/mesh.py` — fix `@click.command()` import-time typo
- `transform/upload.py` — give `--secret-json` a unique short flag (`-k`)
- `parsing/scanlog_fetch.py` — fix `exist_ok`
- `transform/normalize.py` — make `--processes` an `INT`
- `transform/df_write_tiff.py` — use `source.getTitle()` and allow Dragonfly path overrides via env vars
- `transform/hdf_convert.py` — use a POSIX-safe `raw/*.hdf` glob
- `transport/s3upload.py` — stop calling nonexistent `boto3` client `close()`
- `ng/layer_tag.py` — keep retrying generated intensities by storing the replacement result
- `transform/sino_preproc.py` — return bounds arrays and aggregate them with the correct call shape
- `transform/multitrim.py` — apply vertical trim to axis 0 and horizontal trim to axis 1
- `ng/layer_extract.py`, `ng/point_shift.py`, `ng/point_sort.py` — rename click functions to match the files

## Note on `ng/layer_urlshift.py`
`REFACTOR_PLAN.md` flagged the `json_data["layers"] == shifted_layers` line as a broken assignment. I checked the actual behavior before changing it: the command already mutates the underlying layer dicts in place through the `shifted_layers` view, so changing that line to `=` would actually corrupt the output shape by replacing the list with a dict. I left the implementation alone and added a regression test for the current in-place behavior.

## Verification
- `python -m pip install --no-deps -e .`
- `python -m flake8 mctutil scripts tests`
- `python scripts/check_python_tabs.py`
- `pytest tests -q`
- `mctutil --help`
- `git diff --check`
