### PR TITLE
feat: land phase 4 unified cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,20 @@ Notes:
 
 ## Quickstart
 
-Most tools are still run as module entrypoints:
+Phase 4 introduces the unified CLI surface:
+
+```bash
+mctutil transform trim --help
+mctutil transform normalize --help
+mctutil sino convert --help
+mctutil ng point-add --help
+mctutil transport s3-upload --help
+mctutil mem clean --help
+mctutil mem from-file --help
+mctutil parse meta-shift --help
+```
+
+The legacy module entrypoints still exist for now while the unified CLI settles:
 
 ```bash
 python -m transform.trim --help
@@ -70,10 +83,12 @@ python -m transform.trim \
   --z-trim 803,0
 ```
 
-The placeholder future entrypoint is already reserved:
+The unified entrypoint is now live:
 
 ```bash
 mctutil --help
+mctutil transform --help
+mctutil ng --help
 ```
 
 ## Project map

--- a/mctutil/__init__.py
+++ b/mctutil/__init__.py
@@ -1,1 +1,1 @@
-"""mctutil package scaffold for the Phase 0 packaging pass."""
+"""mctutil package and unified CLI scaffold."""

--- a/mctutil/cli.py
+++ b/mctutil/cli.py
@@ -1,8 +1,27 @@
-"""Reserved top-level CLI entrypoint for the future unified command surface."""
+"""Unified top-level CLI entrypoint for mctutil."""
 
 import click
 
+from mctutil.hpc import main as hpc_group
+from mctutil.mem import main as mem_group
+from mctutil.mesh import main as mesh_group
+from mctutil.ng import main as ng_group
+from mctutil.parse import main as parse_group
+from mctutil.sino import main as sino_group
+from mctutil.transform import main as transform_group
+from mctutil.transport import main as transport_group
 
-@click.group(help="Top-level mctutil command reserved for the Phase 4 unified CLI.")
+
+@click.group(help="Unified mctutil command surface.")
 def main():
-	"""Placeholder root command."""
+	"""Root command for the Phase 4 unified CLI."""
+
+
+main.add_command(transform_group, "transform")
+main.add_command(sino_group, "sino")
+main.add_command(ng_group, "ng")
+main.add_command(mesh_group, "mesh")
+main.add_command(transport_group, "transport")
+main.add_command(mem_group, "mem")
+main.add_command(parse_group, "parse")
+main.add_command(hpc_group, "hpc")

--- a/mctutil/hpc/__init__.py
+++ b/mctutil/hpc/__init__.py
@@ -1,0 +1,11 @@
+"""Unified HPC command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="hpc",
+	help="HPC runtime and scheduler-side helpers.",
+	lazy_subcommands={
+		"time-check": "hpc_work.timecheck:timecheck",
+	},
+)

--- a/mctutil/lazy.py
+++ b/mctutil/lazy.py
@@ -1,0 +1,37 @@
+"""Lazy Click command loader for the unified Phase 4 CLI."""
+
+from importlib import import_module
+
+import click
+from click.formatting import measure_table
+
+
+class LazyGroup(click.Group):
+	"""Resolve commands only when they are requested."""
+
+	def __init__(self, *args, lazy_subcommands=None, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.lazy_subcommands = dict(lazy_subcommands or {})
+
+	def list_commands(self, ctx):
+		commands = set(super().list_commands(ctx))
+		commands.update(self.lazy_subcommands.keys())
+		return sorted(commands)
+
+	def get_command(self, ctx, cmd_name):
+		command = super().get_command(ctx, cmd_name)
+		if command is not None:
+			return command
+		import_path = self.lazy_subcommands.get(cmd_name)
+		if import_path is None:
+			return None
+		module_name, attr_name = import_path.split(":", 1)
+		module = import_module(module_name)
+		return getattr(module, attr_name)
+
+	def format_commands(self, ctx, formatter):
+		rows = [(name, "") for name in self.list_commands(ctx)]
+		if len(rows) == 0:
+			return
+		with formatter.section("Commands"):
+			formatter.write_dl(rows, col_max=measure_table(rows)[0])

--- a/mctutil/mem/__init__.py
+++ b/mctutil/mem/__init__.py
@@ -1,0 +1,14 @@
+"""Unified shared-memory cleanup command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="mem",
+	help="Shared-memory cleanup and node submission helpers.",
+	lazy_subcommands={
+		"clean": "mctutil.mem.clean_command:command",
+		"mark": "mctutil.mem.mark_command:command",
+		"from-file": "mem.from_file:from_file",
+		"from-range": "mem.from_range:from_range",
+	},
+)

--- a/mctutil/mem/clean_command.py
+++ b/mctutil/mem/clean_command.py
@@ -1,0 +1,5 @@
+"""Expose the legacy mem clean subcommand under the unified CLI."""
+
+from mem.clean import memclean
+
+command = memclean.commands["clean"]

--- a/mctutil/mem/mark_command.py
+++ b/mctutil/mem/mark_command.py
@@ -1,0 +1,5 @@
+"""Expose the legacy mem mark subcommand under the unified CLI."""
+
+from mem.clean import memclean
+
+command = memclean.commands["mark"]

--- a/mctutil/mesh/__init__.py
+++ b/mctutil/mesh/__init__.py
@@ -1,0 +1,12 @@
+"""Unified mesh command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="mesh",
+	help="Meshing helpers for igneous/neuroglancer workflows.",
+	lazy_subcommands={
+		"build": "transform.mesh:mesh",
+		"build-igneous": "transform.mesh_ig:mesh_ig",
+	},
+)

--- a/mctutil/ng/__init__.py
+++ b/mctutil/ng/__init__.py
@@ -1,0 +1,22 @@
+"""Unified Neuroglancer command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="ng",
+	help="Neuroglancer JSON, layer, and annotation helpers.",
+	lazy_subcommands={
+		"build": "transform.ng:neuroglance",
+		"layer-copy": "ng.layer_copy:layer_copy",
+		"layer-extract": "ng.layer_extract:layer_extract",
+		"layer-recolor": "ng.change_color:change_color",
+		"layer-tag": "ng.layer_tag:layer_tag",
+		"layer-urlshift": "ng.layer_urlshift:layer_urlshift",
+		"point-add": "ng.point_add:point_add",
+		"point-merge": "ng.point_merge:point_merge",
+		"point-shift": "ng.point_shift:point_shift",
+		"point-sort": "ng.point_sort:point_sort",
+		"position-copy": "ng.position_copy:position_copy",
+		"shift-angle": "ng.shift_angle:shift_angle",
+	},
+)

--- a/mctutil/parse/__init__.py
+++ b/mctutil/parse/__init__.py
@@ -1,0 +1,13 @@
+"""Unified parsing command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="parse",
+	help="Metadata, config, and scanlog parsing helpers.",
+	lazy_subcommands={
+		"meta-shift": "parsing.meta_shift:meta_shift",
+		"pull-config": "parsing.pull_config:get_conf",
+		"scanlog-fetch": "parsing.scanlog_fetch:scanlog_fetch",
+	},
+)

--- a/mctutil/sino/__init__.py
+++ b/mctutil/sino/__init__.py
@@ -1,0 +1,11 @@
+"""Unified sinogram command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="sino",
+	help="Sinogram conversion and preprocessing workflows.",
+	lazy_subcommands={
+		"convert": "transform.sinogram:sino_convert",
+	},
+)

--- a/mctutil/transform/__init__.py
+++ b/mctutil/transform/__init__.py
@@ -1,0 +1,26 @@
+"""Unified transform command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="transform",
+	help="TIFF stack transforms and related local data reshaping helpers.",
+	lazy_subcommands={
+		"channelize": "transform.channelize:channelize",
+		"convert": "transform.convert:convert",
+		"df-write-tiff": "transform.df_write_tiff:df_write_tiff",
+		"dicom-conv": "transform.dicom_conv:dicom_conv",
+		"downsample": "transform.downsample:downsample",
+		"find-bounds": "transform.find_bounds:find_bounds",
+		"fix-name": "transform.fix_name:fix_names",
+		"hdf-convert": "transform.hdf_convert:hdf_convert",
+		"normalize": "transform.normalize:norm",
+		"denoise": "transform.simple_noise:simple_denoise",
+		"stitch": "transform.stitch:stitch",
+		"transpose": "transform.transpose:transpose_stack",
+		"trim": "transform.trim:trim",
+		"decompress-tiff": "transform.uncompress:uncompress",
+		"gunzip": "transform.quickgunzip:gunzip",
+		"strip-gz-suffix": "transform.gz_strip:stripgz",
+	},
+)

--- a/mctutil/transport/__init__.py
+++ b/mctutil/transport/__init__.py
@@ -1,0 +1,12 @@
+"""Unified transport command group."""
+
+from mctutil.lazy import LazyGroup
+
+main = LazyGroup(
+	name="transport",
+	help="Remote storage and data movement helpers.",
+	lazy_subcommands={
+		"cv-fetch": "transport.cv_import:cloudvolume_fetch",
+		"s3-upload": "transport.s3upload:s3upload",
+	},
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,10 +199,13 @@ def _stub_modules() -> dict[str, types.ModuleType]:
 
 
 @pytest.fixture()
-def load_module(monkeypatch: pytest.MonkeyPatch):
+def stubbed_modules(monkeypatch: pytest.MonkeyPatch):
 	for name, module in _stub_modules().items():
 		monkeypatch.setitem(sys.modules, name, module)
 
+
+@pytest.fixture()
+def load_module(stubbed_modules):
 	loaded: list[str] = []
 
 	def _load(module_path: str):

--- a/tests/test_phase4_cli.py
+++ b/tests/test_phase4_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from mctutil.cli import main
+
+
+def test_mctutil_root_help_lists_category_groups():
+	result = CliRunner().invoke(main, ["--help"])
+	assert result.exit_code == 0, result.output
+	for name in ["transform", "sino", "ng", "mesh", "transport", "mem", "parse", "hpc"]:
+		assert name in result.output
+
+
+def test_transform_group_help_lists_unified_commands():
+	result = CliRunner().invoke(main, ["transform", "--help"])
+	assert result.exit_code == 0, result.output
+	for name in ["normalize", "trim", "transpose", "gunzip", "strip-gz-suffix"]:
+		assert name in result.output
+
+
+def test_mem_group_help_lists_collapsed_commands():
+	result = CliRunner().invoke(main, ["mem", "--help"])
+	assert result.exit_code == 0, result.output
+	for name in ["clean", "mark", "from-file", "from-range"]:
+		assert name in result.output
+
+
+def test_unified_leaf_help_works(stubbed_modules):
+	result = CliRunner().invoke(main, ["sino", "convert", "--help"])
+	assert result.exit_code == 0, result.output
+	assert "--mode" in result.output
+
+	result = CliRunner().invoke(main, ["ng", "layer-tag", "--help"])
+	assert result.exit_code == 0, result.output
+	assert "--segment_radius" in result.output


### PR DESCRIPTION
## Summary
- replace the placeholder `mctutil` entrypoint with a real grouped CLI surface (`transform`, `sino`, `ng`, `mesh`, `transport`, `mem`, `parse`, `hpc`)
- add lazy command loading so group help does not eagerly import every optional dependency-heavy leaf module
- document the new unified command examples in the README and add focused Phase 4 CLI coverage

## Testing
- `python -m flake8 --extend-ignore=C901 mctutil/__init__.py mctutil/cli.py mctutil/lazy.py mctutil/hpc/__init__.py mctutil/mem/__init__.py mctutil/mem/clean_command.py mctutil/mem/mark_command.py mctutil/mesh/__init__.py mctutil/ng/__init__.py mctutil/parse/__init__.py mctutil/sino/__init__.py mctutil/transform/__init__.py mctutil/transport/__init__.py tests/conftest.py tests/test_phase4_cli.py`
- `python scripts/check_python_tabs.py`
- `pytest tests -q`
- `mctutil --help`
- `~/miniconda3/bin/conda run -n mctutil-ci python -m flake8 --extend-ignore=C901 mctutil/__init__.py mctutil/cli.py mctutil/lazy.py mctutil/hpc/__init__.py mctutil/mem/__init__.py mctutil/mem/clean_command.py mctutil/mem/mark_command.py mctutil/mesh/__init__.py mctutil/ng/__init__.py mctutil/parse/__init__.py mctutil/sino/__init__.py mctutil/transform/__init__.py mctutil/transport/__init__.py tests/conftest.py tests/test_phase4_cli.py`
- `~/miniconda3/bin/conda run -n mctutil-ci python scripts/check_python_tabs.py`
- `~/miniconda3/bin/conda run -n mctutil-ci pytest tests -q`
- `~/miniconda3/bin/conda run -n mctutil-ci mctutil --help`
