### PR TITLE
test: land phase 5 real behavior coverage

### DIFF
--- a/tests/test_phase5_real_behavior.py
+++ b/tests/test_phase5_real_behavior.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import tifffile
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class SerialPool:
+	def __init__(self, *_args, **_kwargs):
+		pass
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, exc_type, exc, tb):
+		return False
+
+	def starmap(self, func, iterable):
+		return [func(*args) for args in iterable]
+
+
+def test_trim_crops_xy_and_z_ranges(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/trim.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "start", lambda: None)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+
+	for index in range(3):
+		data = np.arange(16, dtype=np.uint8).reshape(4, 4) + index * 20
+		tifffile.imwrite(input_dir / f"slice_{index}.tif", data)
+
+	result = CliRunner().invoke(
+		module.trim,
+		[
+			"-d", str(input_dir),
+			"-o", str(output_dir),
+			"-v", "1,1",
+			"-h", "1,1",
+			"-z", "1,0",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	written = sorted(output_dir.glob("*.tif"))
+	assert [path.name for path in written] == ["slice_1.tif", "slice_2.tif"]
+	assert tifffile.imread(written[0]).tolist() == [[25, 26], [29, 30]]
+	assert tifffile.imread(written[1]).tolist() == [[45, 46], [49, 50]]
+
+
+def test_normalize_handles_partial_final_batch(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/normalize.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "start", lambda: None)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	output_dir.mkdir()
+	data = np.array([[0.0, 5.0], [10.0, 15.0]], dtype=np.float32)
+	tifffile.imwrite(input_dir / "slice_0.tif", data)
+
+	result = CliRunner().invoke(
+		module.norm,
+		[
+			"-n", "0,100",
+			"-d", str(input_dir),
+			"-o", str(output_dir),
+			"-p", "2",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	written = tifffile.imread(output_dir / "slice_0.tif")
+	assert written.dtype == np.float32
+	assert np.allclose(written, np.array([[0.0, 1.0 / 3.0], [2.0 / 3.0, 1.0]], dtype=np.float32))
+
+
+def test_sinogram_preproc_normalizes_small_real_input(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/sinogram.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module, "estimate_sigma", lambda *_args, **_kwargs: 0.0)
+	monkeypatch.setattr(module, "denoise_nl_means", lambda data, **_kwargs: data)
+
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	output_dir.mkdir()
+	tifffile.imwrite(input_dir / "sino_0.tif", np.array([[2.0, 4.0], [6.0, 8.0]], dtype=np.float32))
+
+	result = CliRunner().invoke(
+		module.sino_convert,
+		[
+			"--mode", "preproc",
+			"-i", str(input_dir),
+			"-o", str(output_dir),
+			"-p", "1",
+			"--min-val", "2",
+			"--max-val", "8",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	written = tifffile.imread(output_dir / "sino_0.tif")
+	assert np.allclose(written, np.array([[0.0, 1.0 / 3.0], [2.0 / 3.0, 1.0]], dtype=np.float32))

--- a/transform/normalize.py
+++ b/transform/normalize.py
@@ -74,10 +74,8 @@ def mem_write(mem: SharedNP, path: PathLike, i, dtype):
 def norm(normalize_over, data_dir, output_dir, processes):
 	log.start()
 
-	indices = list(range(processes))
-
 	Path(output_dir).mkdir(parents=True, exist_ok=True)
-	inputs = [x for x in Path(data_dir).iterdir() if ".tif" in x.name]
+	inputs = sorted([x for x in Path(data_dir).iterdir() if ".tif" in x.name])
 	batched_input = list(batch(inputs, processes))
 
 	log.log("Initialize", "Inputs Batched")
@@ -90,13 +88,14 @@ def norm(normalize_over, data_dir, output_dir, processes):
 
 	with SharedNP('Normalize_Mem', np.float32, mem_shape, create=True) as norm_mem:
 		for input_set in batched_input:
+			active_indices = list(range(len(input_set)))
 			with Pool(processes) as pool:
-				pool.starmap(memreader, [(norm_mem, i, input_set[i]) for i in indices])
-			log.log("Image Load", f"{len(indices)} Images Loaded")
-			normalize(norm_mem, indices, normalize_over.start, normalize_over.stop, processes)
+				pool.starmap(memreader, [(norm_mem, i, input_set[i]) for i in active_indices])
+			log.log("Image Load", f"{len(active_indices)} Images Loaded")
+			normalize(norm_mem, active_indices, normalize_over.start, normalize_over.stop, processes)
 			with Pool(processes) as pool:
-				pool.starmap(mem_write, [(norm_mem, Path(output_dir, input_set[i].name), i, dtype) for i in indices])
-			log.log("Image Writing", f"{len(indices)} Images Written")
+				pool.starmap(mem_write, [(norm_mem, Path(output_dir, input_set[i].name), i, dtype) for i in active_indices])
+			log.log("Image Writing", f"{len(active_indices)} Images Written")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add real small-TIFF behavioral coverage for `transform.trim`, `transform.normalize`, and sinogram preproc mode
- patch `transform.normalize` so a final partial batch no longer indexes past the available input set
- keep Phase 5 narrow to the first concrete coverage slice instead of mixing in the broader polish backlog

## Testing
- `python -m flake8 --extend-ignore=C901 transform/normalize.py tests/test_phase5_real_behavior.py tests/test_phase4_cli.py tests/test_phase3_collapses.py tests/test_phase1_regressions.py`
- `python scripts/check_python_tabs.py`
- `pytest tests -q`
- `mctutil --help`
- `/home/sorotassu/miniconda3/bin/conda run -n mctutil-ci python -m flake8 --extend-ignore=C901 transform/normalize.py tests/test_phase5_real_behavior.py tests/test_phase4_cli.py tests/test_phase3_collapses.py tests/test_phase1_regressions.py`
- `~/miniconda3/bin/conda run -n mctutil-ci python scripts/check_python_tabs.py`
- `~/miniconda3/bin/conda run -n mctutil-ci pytest tests -q`
- `~/miniconda3/bin/conda run -n mctutil-ci mctutil --help`
