### PR TITLE
feat: extend phase 5 dry-run and sino coverage

### DIFF
--- a/tests/test_phase5_real_behavior.py
+++ b/tests/test_phase5_real_behavior.py
@@ -24,6 +24,13 @@ class SerialPool:
 		return [func(*args) for args in iterable]
 
 
+def fake_distribute_read(target_mem, _pj, window, _int_window, image_order, **_kwargs):
+	with target_mem as target:
+		for projection_index, image_path in image_order:
+			image = tifffile.imread(image_path)
+			target[projection_index, :len(window), :] = image[list(window), :]
+
+
 def test_trim_crops_xy_and_z_ranges(load_module, tmp_path, monkeypatch):
 	module = load_module("transform/trim.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
@@ -56,6 +63,26 @@ def test_trim_crops_xy_and_z_ranges(load_module, tmp_path, monkeypatch):
 	assert tifffile.imread(written[1]).tolist() == [[45, 46], [49, 50]]
 
 
+def test_trim_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/trim.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "start", lambda: None)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	tifffile.imwrite(input_dir / "slice_0.tif", np.arange(16, dtype=np.uint8).reshape(4, 4))
+
+	result = CliRunner().invoke(
+		module.trim,
+		["-d", str(input_dir), "-o", str(output_dir), "--dry-run"],
+	)
+
+	assert result.exit_code == 0, result.output
+	assert not output_dir.exists()
+
+
 def test_normalize_handles_partial_final_batch(load_module, tmp_path, monkeypatch):
 	module = load_module("transform/normalize.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
@@ -83,6 +110,32 @@ def test_normalize_handles_partial_final_batch(load_module, tmp_path, monkeypatc
 	written = tifffile.imread(output_dir / "slice_0.tif")
 	assert written.dtype == np.float32
 	assert np.allclose(written, np.array([[0.0, 1.0 / 3.0], [2.0 / 3.0, 1.0]], dtype=np.float32))
+
+
+def test_normalize_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/normalize.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "start", lambda: None)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	tifffile.imwrite(input_dir / "slice_0.tif", np.array([[0.0, 5.0], [10.0, 15.0]], dtype=np.float32))
+
+	result = CliRunner().invoke(
+		module.norm,
+		[
+			"-n", "0,100",
+			"-d", str(input_dir),
+			"-o", str(output_dir),
+			"-p", "1",
+			"--dry-run",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	assert not output_dir.exists()
 
 
 def test_sinogram_preproc_normalizes_small_real_input(load_module, tmp_path, monkeypatch):
@@ -113,3 +166,70 @@ def test_sinogram_preproc_normalizes_small_real_input(load_module, tmp_path, mon
 	assert result.exit_code == 0, result.output
 	written = tifffile.imread(output_dir / "sino_0.tif")
 	assert np.allclose(written, np.array([[0.0, 1.0 / 3.0], [2.0 / 3.0, 1.0]], dtype=np.float32))
+
+
+def test_sinogram_full_mode_normalizes_small_real_input(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/sinogram.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module, "distribute_read", fake_distribute_read)
+
+	input_dir = tmp_path / "input"
+	flat_dir = tmp_path / "flats"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	flat_dir.mkdir()
+	output_dir.mkdir()
+
+	tifffile.imwrite(input_dir / "proj_0.tif", np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32))
+	for name, data in {
+		"pregain_median.tiff": np.ones((2, 2), dtype=np.float32),
+		"postgain_median.tiff": np.ones((2, 2), dtype=np.float32),
+		"predark_median.tiff": np.zeros((2, 2), dtype=np.float32),
+		"postdark_median.tiff": np.zeros((2, 2), dtype=np.float32),
+	}.items():
+		tifffile.imwrite(flat_dir / name, data)
+
+	result = CliRunner().invoke(
+		module.sino_convert,
+		[
+			"--mode", "full",
+			"-i", str(input_dir),
+			"-o", str(output_dir),
+			"-f", str(flat_dir),
+			"-p", "1",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	assert tifffile.imread(output_dir / "sino_00000.tiff").tolist() == [[1.0, 2.0]]
+	assert tifffile.imread(output_dir / "sino_00001.tiff").tolist() == [[3.0, 4.0]]
+
+
+def test_sinogram_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
+	module = load_module("transform/sinogram.py")
+	monkeypatch.setattr(module, "Pool", SerialPool)
+	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module, "estimate_sigma", lambda *_args, **_kwargs: 0.0)
+	monkeypatch.setattr(module, "denoise_nl_means", lambda data, **_kwargs: data)
+
+	input_dir = tmp_path / "input"
+	output_dir = tmp_path / "output"
+	input_dir.mkdir()
+	tifffile.imwrite(input_dir / "sino_0.tif", np.array([[2.0, 4.0], [6.0, 8.0]], dtype=np.float32))
+
+	result = CliRunner().invoke(
+		module.sino_convert,
+		[
+			"--mode", "preproc",
+			"-i", str(input_dir),
+			"-o", str(output_dir),
+			"-p", "1",
+			"--min-val", "2",
+			"--max-val", "8",
+			"--dry-run",
+		],
+	)
+
+	assert result.exit_code == 0, result.output
+	assert not output_dir.exists()

--- a/transform/normalize.py
+++ b/transform/normalize.py
@@ -58,10 +58,14 @@ def memreader(mem, i, path):
 		mem_array[i] = tf.imread(path)
 
 
-def mem_write(mem: SharedNP, path: PathLike, i, dtype):
+def mem_write(mem: SharedNP, path: PathLike, i, dtype, execute=True):
 	"""Writes to disk in distributed fashion."""
 	with mem[i] as out_data:
-		tf.imwrite(path, np_convert(dtype, out_data), dtype=dtype)
+		if execute:
+			tf.imwrite(path, np_convert(dtype, out_data), dtype=dtype)
+			log.log("File Written", path.name)
+		else:
+			log.log("Dry Run", f"Would write {path.name}")
 
 
 @click.command()
@@ -71,10 +75,13 @@ def mem_write(mem: SharedNP, path: PathLike, i, dtype):
 				help='Output path for cleaned images', default='data/clean/')
 @click.option('-p', '--processes', type=click.INT, default=psutil.cpu_count(),
 				help='Process Count (for simulatenous images)')
-def norm(normalize_over, data_dir, output_dir, processes):
+@click.option('--execute/--dry-run', default=True,
+				help='Whether to write normalized files or only log the planned outputs.')
+def norm(normalize_over, data_dir, output_dir, processes, execute):
 	log.start()
 
-	Path(output_dir).mkdir(parents=True, exist_ok=True)
+	if execute:
+		Path(output_dir).mkdir(parents=True, exist_ok=True)
 	inputs = sorted([x for x in Path(data_dir).iterdir() if ".tif" in x.name])
 	batched_input = list(batch(inputs, processes))
 
@@ -94,8 +101,11 @@ def norm(normalize_over, data_dir, output_dir, processes):
 			log.log("Image Load", f"{len(active_indices)} Images Loaded")
 			normalize(norm_mem, active_indices, normalize_over.start, normalize_over.stop, processes)
 			with Pool(processes) as pool:
-				pool.starmap(mem_write, [(norm_mem, Path(output_dir, input_set[i].name), i, dtype) for i in active_indices])
-			log.log("Image Writing", f"{len(active_indices)} Images Written")
+				pool.starmap(
+					mem_write,
+					[(norm_mem, Path(output_dir, input_set[i].name), i, dtype, execute) for i in active_indices],
+				)
+			log.log("Image Writing", f"{len(active_indices)} Images {'Written' if execute else 'Planned'}")
 
 
 if __name__ == '__main__':

--- a/transform/sinogram.py
+++ b/transform/sinogram.py
@@ -26,21 +26,34 @@ def weighted_normalize(sino_mem: SharedNP, input_mem: SharedNP, flats_mem: Share
 					projection: int, projection_count: int, debug_folder: Path = None):
 	"""Normalizes single projection using weighted pre/post flats."""
 	with sino_mem[int_window] as sino, flats_mem as flats, input_mem as source:
-		dark_map = np.average(flats[FLAT.PREDARK.index:FLAT.POSTDARK.index + 1, window, :], axis=0,
-							weights=[projection_count - projection, projection])
-		gain_map = np.subtract(np.average(flats[FLAT.PREGAIN.index:FLAT.POSTGAIN.index + 1, window, :], axis=0,
-							weights=[projection_count - projection, projection]), dark_map)
+		dark_map = np.average(
+			flats[FLAT.PREDARK.index:FLAT.POSTDARK.index + 1, window, :],
+			axis=0,
+			weights=[projection_count - projection, projection],
+		)
+		gain_map = np.subtract(
+			np.average(
+				flats[FLAT.PREGAIN.index:FLAT.POSTGAIN.index + 1, window, :],
+				axis=0,
+				weights=[projection_count - projection, projection],
+			),
+			dark_map,
+		)
 		gain_map[gain_map == 0] = np.min(gain_map[gain_map != 0])
 		temp = np.subtract(source[projection, int_window, :].astype(sino_mem.dtype), dark_map)
 		sino[int_window, projection, :] = np.divide(temp, gain_map)
 
 
-def sino_write(sino_mem: SharedNP, path: PathLike, i, out_type: cli.NumpyCLI = None):
+def sino_write(sino_mem: SharedNP, path: PathLike, i, out_type: cli.NumpyCLI = None, execute=True):
 	with sino_mem as sino:
-		if out_type is None:
-			tf.imwrite(path, sino[i, :, :])
+		if execute:
+			if out_type is None:
+				tf.imwrite(path, sino[i, :, :])
+			else:
+				tf.imwrite(path, out_type.convert_ar(sino[i, :, :]))
+			log.log("File Written", str(path))
 		else:
-			tf.imwrite(path, out_type.convert_ar(sino[i, :, :]))
+			log.log("Dry Run", f"Would write {path}")
 
 
 def image_bounds(sino_mem: SharedNP, i: int = None):
@@ -49,7 +62,7 @@ def image_bounds(sino_mem: SharedNP, i: int = None):
 			return np.array([np.min(sino), np.max(sino)])
 	with sino_mem[i] as sino:
 		if np.max(sino) > 2:
-			print(np.max(sino))
+			log.log("Bounds Check", f"Peak value {np.max(sino):.4g}", log_level=log.DEBUG.INFO)
 		return np.array([np.min(sino), np.max(sino)])
 
 
@@ -65,9 +78,15 @@ def minmaxscale(sino_mem, i, minval=None, maxval=None):
 def remove_outlier(sino_mem, i):
 	with sino_mem[i] as sino:
 		a_sigma_est = estimate_sigma(sino, channel_axis=None, average_sigmas=True)
-		sino[:, :] = denoise_nl_means(sino, patch_size=9, patch_distance=5,
-							fast_mode=True, sigma=0.001 * a_sigma_est,
-							preserve_range=False, channel_axis=None)
+		sino[:, :] = denoise_nl_means(
+			sino,
+			patch_size=9,
+			patch_distance=5,
+			fast_mode=True,
+			sigma=0.001 * a_sigma_est,
+			preserve_range=False,
+			channel_axis=None,
+		)
 
 
 def preprocess(sino_mem, i, minval=None, maxval=None):
@@ -86,15 +105,20 @@ def validate_mode(mode: str, flat_dir: Path | None):
 
 
 def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: int, sectioning: int,
-			sino_range: range):
+			sino_range: range, execute=True):
 	image_paths = natsort.natsorted(list(input_dir.glob("**/*.tif*")))
 	segment_id = str(uuid.uuid4())
 	internal_dtype = np.float32
 
 	with tf.TiffFile(image_paths[0]) as tif:
 		page = tif.pages[0]
-		pj = {"dtype": page.dtype, "bytesize": page.dtype.itemsize, "offset": page.dataoffsets[0],
-				"x": page.shape[1], "y": page.shape[0]}
+		pj = {
+			"dtype": page.dtype,
+			"bytesize": page.dtype.itemsize,
+			"offset": page.dataoffsets[0],
+			"x": page.shape[1],
+			"y": page.shape[0],
+		}
 
 	if sino_range is None:
 		sino_split = range(0, pj["y"], process_count)
@@ -102,19 +126,32 @@ def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: i
 		sino_split = range(sino_range.start, sino_range.stop, process_count)
 
 	if sectioning:
-		output_paths = [output_dir.joinpath(f"section_{x - x % sectioning:03}_{x - x % sectioning + sectioning:03}",
-							f"sino_{x % sectioning:05}.tiff") for x in range(pj["y"])]
+		output_paths = [
+			output_dir.joinpath(
+				f"section_{x - x % sectioning:03}_{x - x % sectioning + sectioning:03}",
+				f"sino_{x % sectioning:05}.tiff",
+			)
+			for x in range(pj["y"])
+		]
 	else:
-		output_dir.mkdir(parents=True, exist_ok=True)
+		if execute:
+			output_dir.mkdir(parents=True, exist_ok=True)
 		output_paths = [output_dir.joinpath(f"sino_{x:05}.tiff") for x in range(pj["y"])]
 
 	sino_shape = SinoOrder(process_count, len(image_paths), pj["x"])
 	proj_shape = ProjOrder(len(image_paths), process_count, pj["x"])
 	log.log("Setup", f"{pj}")
 
-	with (SharedNP(f'flats_{segment_id}', pj["dtype"], ProjOrder(len(FLAT), pj["y"], pj["x"]), create=True) as flats_mem,
-			SharedNP(f"sino_{segment_id}", internal_dtype, sino_shape, create=True) as sino_mem,
-			SharedNP(f"input_{segment_id}", pj["dtype"], proj_shape, create=True) as input_mem):
+	with (
+		SharedNP(
+			f'flats_{segment_id}',
+			pj["dtype"],
+			ProjOrder(len(FLAT), pj["y"], pj["x"]),
+			create=True,
+		) as flats_mem,
+		SharedNP(f"sino_{segment_id}", internal_dtype, sino_shape, create=True) as sino_mem,
+		SharedNP(f"input_{segment_id}", pj["dtype"], proj_shape, create=True) as input_mem,
+	):
 		with flats_mem as flat_set:
 			for flat in list(FLAT):
 				flat_set[flat.index, :, :] = tf.imread(flat_dir.joinpath(f"{flat}_median.tiff")).astype(internal_dtype)
@@ -134,18 +171,31 @@ def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: i
 			)
 			log.log("Files Read", f"Window {window}; Shape {proj_shape}")
 			with Pool(process_count) as pool:
-				pool.starmap(weighted_normalize, [(sino_mem, input_mem, flats_mem, window, internal_window, i, sino_mem.shape.Theta)
-										for i in range(sino_mem.shape.Theta)])
-			for section_dir in set([fullpath.parent for fullpath in output_paths[window.start:window.stop]]):
-				section_dir.mkdir(parents=True, exist_ok=True)
+				pool.starmap(
+					weighted_normalize,
+					[(sino_mem, input_mem, flats_mem, window, internal_window, i, sino_mem.shape.Theta)
+						for i in range(sino_mem.shape.Theta)],
+				)
+			if execute:
+				for section_dir in set([fullpath.parent for fullpath in output_paths[window.start:window.stop]]):
+					section_dir.mkdir(parents=True, exist_ok=True)
 			with Pool(process_count) as pool:
-				pool.starmap(sino_write, [(sino_mem, output_paths[i + window.start], i) for i in internal_window])
-			log.log("Files Written", f"{output_dir} : {window}", log.DEBUG.TIME)
+				pool.starmap(
+					sino_write,
+					[(sino_mem, output_paths[i + window.start], i, None, execute) for i in internal_window],
+				)
+			log.log(
+				"Files Written",
+				f"{output_dir} : {window} ({'written' if execute else 'planned'})",
+				log.DEBUG.TIME,
+			)
 
 
-def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: float | None, max_val: float | None):
+def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: float | None, max_val: float | None,
+			execute=True):
 	image_paths = natsort.natsorted(list(input_dir.glob("**/*.tif*")))
-	output_dir.mkdir(parents=True, exist_ok=True)
+	if execute:
+		output_dir.mkdir(parents=True, exist_ok=True)
 	output_paths = [output_dir.joinpath(x.name) for x in image_paths]
 
 	segment_id = str(uuid.uuid4())
@@ -153,8 +203,13 @@ def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: 
 
 	with tf.TiffFile(image_paths[0]) as tif:
 		page = tif.pages[0]
-		pj = {"dtype": page.dtype, "bytesize": page.dtype.itemsize, "offset": page.dataoffsets[0],
-				"x": page.shape[1], "y": page.shape[0]}
+		pj = {
+			"dtype": page.dtype,
+			"bytesize": page.dtype.itemsize,
+			"offset": page.dataoffsets[0],
+			"x": page.shape[1],
+			"y": page.shape[0],
+		}
 
 	sino_shape = SinoOrder(process_count, pj["y"], pj["x"])
 	bounds = []
@@ -182,8 +237,15 @@ def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: 
 			with Pool(process_count) as pool:
 				pool.starmap(preprocess, [(sino_mem, i, min_val, max_val) for i in internal_window])
 			with Pool(process_count) as pool:
-				pool.starmap(sino_write, [(sino_mem, output_paths[i + window.start], i) for i in internal_window])
-			log.log("Files Written", f"{output_dir} : {window}", log.DEBUG.TIME)
+				pool.starmap(
+					sino_write,
+					[(sino_mem, output_paths[i + window.start], i, None, execute) for i in internal_window],
+				)
+			log.log(
+				"Files Written",
+				f"{output_dir} : {window} ({'written' if execute else 'planned'})",
+				log.DEBUG.TIME,
+			)
 
 
 @click.command()
@@ -203,6 +265,8 @@ def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: 
 				help="Sinogram (projection Y dimension) range to create in full mode.")
 @click.option("--min-val", type=click.FLOAT, default=None, help="Minimum sinogram value for preproc mode.")
 @click.option("--max-val", type=click.FLOAT, default=None, help="Maximum sinogram value for preproc mode.")
+@click.option('--execute/--dry-run', default=True,
+				help='Whether to write sinogram outputs or only log the planned outputs.')
 def sino_convert(
 		mode: str,
 		input_dir: Path,
@@ -213,13 +277,14 @@ def sino_convert(
 		sino_range: range,
 		min_val: float | None,
 		max_val: float | None,
+		execute: bool,
 ):
 	mode = mode.lower()
 	validate_mode(mode, flat_dir)
 	if mode == "full":
-		run_full(input_dir, output_dir, flat_dir, process_count, sectioning, sino_range)
+		run_full(input_dir, output_dir, flat_dir, process_count, sectioning, sino_range, execute=execute)
 	else:
-		run_preproc(input_dir, output_dir, process_count, min_val, max_val)
+		run_preproc(input_dir, output_dir, process_count, min_val, max_val, execute=execute)
 
 
 if __name__ == "__main__":

--- a/transform/trim.py
+++ b/transform/trim.py
@@ -10,13 +10,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from shared import cli, log 	# noqa::E402
 
 
-def write_crop(input, output, crop, compress):
+def write_crop(input, output, crop, compress, execute=True):
 	img = tf.imread(input)
-	if compress:
-		tf.imwrite(output, img[crop], compression=8)
+	if execute:
+		if compress:
+			tf.imwrite(output, img[crop], compression=8)
+		else:
+			tf.imwrite(output, img[crop])
+		log.log("File Written", f"{output.name}: ({img.shape}>{crop})")
 	else:
-		tf.imwrite(output, img[crop])
-	log.log("File Written", f"{output.name}: ({img.shape}>{crop})")
+		log.log("Dry Run", f"Would write {output.name}: ({img.shape}>{crop})")
 
 
 @click.command
@@ -31,14 +34,17 @@ def write_crop(input, output, crop, compress):
 				help='Z-dimension trim (top and bottom) as an absolute value (integer) or percent (float)')
 @click.option('--compressed/--uncompressed', default=False,
 				help='Whether to compress output data.')
-def trim(data_dir, output_dir, vertical_trim, horizontal_trim, z_trim, compressed):
+@click.option('--execute/--dry-run', default=True,
+				help='Whether to write cropped files or only log the planned outputs.')
+def trim(data_dir, output_dir, vertical_trim, horizontal_trim, z_trim, compressed, execute):
 	"""Crop an image stack.
 	Crop values can be a comma separated pair like 5,4 or a single value like 3.
 	Float values are handled as % of image size; integer values as voxel values.
 	"""
 	log.start()
 	out_dir = Path(output_dir)
-	out_dir.mkdir(parents=True, exist_ok=True)
+	if execute:
+		out_dir.mkdir(parents=True, exist_ok=True)
 	path_list = sorted(list(Path(data_dir).glob("*.tif*")))
 	path_list = path_list[cli.crop_val(z_trim, len(path_list))]
 
@@ -48,7 +54,7 @@ def trim(data_dir, output_dir, vertical_trim, horizontal_trim, z_trim, compresse
 	new_dim = (cli.crop_val(vertical_trim, dim[0]), cli.crop_val(horizontal_trim, dim[1]))
 
 	with Pool(64) as pool:
-		pool.starmap(write_crop, [(path, Path(out_dir, path.name), new_dim, compressed) for path in path_list])
+		pool.starmap(write_crop, [(path, Path(out_dir, path.name), new_dim, compressed, execute) for path in path_list])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add real full-mode `sino convert` fixture coverage alongside more dry-run coverage for the core write-heavy transform commands
- add `--execute/--dry-run` support to `transform.trim`, `transform.normalize`, and `transform.sinogram`
- replace the remaining `print`-style debug emission inside `transform.sinogram` with `shared.log.log`

## Testing
- `python -m flake8 --extend-ignore=C901 transform/trim.py transform/normalize.py transform/sinogram.py tests/test_phase5_real_behavior.py`
- `python scripts/check_python_tabs.py`
- `pytest tests -q`
- `mctutil --help`
- `~/miniconda3/bin/conda run -n mctutil-ci python -m flake8 --extend-ignore=C901 transform/trim.py transform/normalize.py transform/sinogram.py tests/test_phase5_real_behavior.py`
- `~/miniconda3/bin/conda run -n mctutil-ci python scripts/check_python_tabs.py`
- `~/miniconda3/bin/conda run -n mctutil-ci pytest tests -q`
- `~/miniconda3/bin/conda run -n mctutil-ci mctutil --help`
