### PR TITLE
Phase 5: print -> log cleanup and next-tier dry-run

### DIFF
--- a/ng/change_color.py
+++ b/ng/change_color.py
@@ -5,6 +5,7 @@ import re
 
 import click
 
+from shared import log
 from shared.cli import DelimitedRecord
 
 
@@ -34,14 +35,14 @@ def change_color(json_file: Path, json_result: Path, annotation: str, segment_co
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Change Color", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	layer_names = [layer["name"] for layer in json_data["layers"]]
 	if annotation not in layer_names:
-		print(f"Annotation {annotation} not found in JSON.")
+		log.log("Change Color", f"Annotation {annotation} not found in JSON.", log_level=log.DEBUG.ERROR)
 		exit(1)
 	elif "segmentColors" not in json_data["layers"][layer_names.index(annotation)]:
-		print(f"No segmentation colors in layer {annotation}")
+		log.log("Change Color", f"No segmentation colors in layer {annotation}", log_level=log.DEBUG.ERROR)
 		exit(1)
 	else:
 		color_layer = json_data["layers"][layer_names.index(annotation)]["segmentColors"]
@@ -49,13 +50,15 @@ def change_color(json_file: Path, json_result: Path, annotation: str, segment_co
 			if str(color_pair.segment) in color_layer:
 				color_layer[str(color_pair.segment)] = color_pair.hval
 			else:
-				print(f"Segmentation ID {color_pair.segment} not found in layer {annotation}.")
+				log.log("Change Color",
+						f"Segmentation ID {color_pair.segment} not found in layer {annotation}.",
+						log_level=log.DEBUG.WARN)
 		json_data["layers"][layer_names.index(annotation)]["segmentColors"] = color_layer
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new arrangement written to {json_result}")
+	log.log("Change Color", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/layer_copy.py
+++ b/ng/layer_copy.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import click
 
+from shared import log
+
 
 @click.command()
 @click.option("--json-file", "-j", type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
@@ -23,7 +25,7 @@ def layer_copy(json_file: Path, json_result: Path, json_target: Path, source_ann
 		json_source = json.load(json_handle)
 	with open(json_target) as json_handle:
 		json_target = json.load(json_handle)
-	print("json loaded")
+	log.log("Layer Copy", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	existing_annotations = [layer["name"] for layer in json_source["layers"]]
 	if len(source_annotations) > 0:
@@ -34,15 +36,15 @@ def layer_copy(json_file: Path, json_result: Path, json_target: Path, source_ann
 	annotations = [layer for layer in json_source["layers"] if
 					((layer["name"] in source_annotations) or (len(source_annotations) == 0))]
 
-	print(f"{len(annotations)} Found to Copy")
+	log.log("Layer Copy", f"{len(annotations)} found to copy", log_level=log.DEBUG.STATUS)
 
 	if len(source_annotations) > len(annotations):
 		missing_annotations = [layer_name for layer_name in source_annotations if layer_name not in existing_annotations]
-		print(f"Annotations Missing: {missing_annotations}\n")
+		log.log("Layer Copy", f"Annotations missing: {missing_annotations}", log_level=log.DEBUG.ERROR)
 		return -1
 
 	if len(duplicate_layers) > 0:
-		print(f"Some layers already exist in target: {duplicate_layers}")
+		log.log("Layer Copy", f"Some layers already exist in target: {duplicate_layers}", log_level=log.DEBUG.ERROR)
 		return -1
 
 	json_target["layers"].extend(annotations)
@@ -50,7 +52,7 @@ def layer_copy(json_file: Path, json_result: Path, json_target: Path, source_ann
 	with open(json_result, "w") as handle:
 		json.dump(json_target, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Layer Copy", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/layer_extract.py
+++ b/ng/layer_extract.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import click
 
+from shared import log
+
 
 @click.command()
 @click.option("--json-file", "-j", type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
@@ -19,15 +21,15 @@ def layer_extract(json_file: Path, json_result: Path, layers: str):
 		"""
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
-	print("json loaded")
+	log.log("Layer Extract", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	source_layers = {layer["name"]: layer for layer in json_data["layers"]}
 	copy_layers = []
 	for layer in layers:
 		if layer not in source_layers:
-			print(f"{layer} not found in source.")
+			log.log("Layer Extract", f"{layer} not found in source.", log_level=log.DEBUG.WARN)
 		else:
-			print(f"{layer} retained.")
+			log.log("Layer Extract", f"{layer} retained.", log_level=log.DEBUG.STATUS)
 			copy_layers.append(source_layers[layer])
 
 	json_data["layers"] = copy_layers
@@ -35,7 +37,7 @@ def layer_extract(json_file: Path, json_result: Path, layers: str):
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Layer Extract", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/layer_tag.py
+++ b/ng/layer_tag.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 import numpy as np
 
+from shared import log
 from shared.cli import DelimitedRecord
 
 
@@ -42,7 +43,7 @@ TAGGEDLAYER = DelimitedRecord(
 def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: TaggedLayer):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
-	print("json loaded")
+	log.log("Layer Tag", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	preset_intensities = [layer.intensity for layer in tagged_layer]
 	intensity_step = np.iinfo(np.uint16).max // (len(tagged_layer) + 2)
@@ -51,7 +52,7 @@ def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: 
 	source_layers = {layer["name"]: layer for layer in json_data["layers"]}
 	for t_layer in tagged_layer:
 		if t_layer.name not in source_layers:
-			print(f"{t_layer} not found in source.")
+			log.log("Layer Tag", f"{t_layer} not found in source.", log_level=log.DEBUG.WARN)
 		else:
 			if t_layer.intensity == -1:
 				t_layer = replace(t_layer, intensity=next(intensity_gen))
@@ -63,14 +64,14 @@ def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: 
 
 			source_layers[t_layer.name]["name"] = str(t_layer)
 
-			print(f"{t_layer.name} updated: {t_layer}.")
+			log.log("Layer Tag", f"{t_layer.name} updated: {t_layer}.", log_level=log.DEBUG.STATUS)
 
 	json_data["layers"] = list(source_layers.values())
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Layer Tag", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/layer_urlshift.py
+++ b/ng/layer_urlshift.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import click
 
+from shared import log
+
 
 def upd_layer(name, source, shifted_layers):
 	if isinstance(source, str):
@@ -37,7 +39,7 @@ def layer_urlshift(json_file: Path, json_result: Path):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Layer URLShift", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	shifted_layers = {layer["name"]: layer for layer in json_data["layers"]}
 	for name, layer in shifted_layers.items():
@@ -49,7 +51,7 @@ def layer_urlshift(json_file: Path, json_result: Path):
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Layer URLShift", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/point_add.py
+++ b/ng/point_add.py
@@ -6,6 +6,8 @@ import uuid
 import click
 import numpy as np
 
+from shared import log
+
 
 @click.command()
 @click.option("--json-file", "-j", type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
@@ -26,7 +28,7 @@ def point_add(json_file: Path, json_result: Path, base_layer: str, points: Path,
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Point Add", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	for layer in json_data["layers"]:
 		if layer["name"] == base_layer:
@@ -54,23 +56,23 @@ def point_add(json_file: Path, json_result: Path, base_layer: str, points: Path,
 			point_reader = csv.reader(csvfile)
 			point_array = np.array([row for row in point_reader])
 	else:
-		print("Points must be in .npy or .csv format.")
+		log.log("Point Add", "Points must be in .npy or .csv format.", log_level=log.DEBUG.ERROR)
 		return
 
 	if len(point_array.shape) != 2 or point_array.shape[-1] != 3:
-		print("Points must be an array of 3D XYZ points.")
+		log.log("Point Add", "Points must be an array of 3D XYZ points.", log_level=log.DEBUG.ERROR)
 		return
 
 	uuids = [uuid.uuid1() for x in range(len(point_array))]
 	new_layer["annotations"] = [{"type": "point", "id": str(idval), "point": list(point)}
 								for point, idval in zip(point_array, uuids)]
 	json_data["layers"].append(new_layer)
-	print("annotation added")
+	log.log("Point Add", "Annotation added", log_level=log.DEBUG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Point Add", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/point_merge.py
+++ b/ng/point_merge.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from shared import log
 from shared.cli import DelimitedRecord
 
 
@@ -35,13 +36,13 @@ def point_merge(json_file: Path, json_result: Path, target_name: str, source_ann
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Point Merge", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	annotation_names = [layer["name"] for layer in json_data["layers"]]
 
 	for pair in source_annotations:
 		if pair.name not in annotation_names:
-			print(f"Annotation {pair.name} missing.")
+			log.log("Point Merge", f"Annotation {pair.name} missing.", log_level=log.DEBUG.ERROR)
 			return
 
 	new_annotation_layer = {
@@ -53,21 +54,21 @@ def point_merge(json_file: Path, json_result: Path, target_name: str, source_ann
 		"name": target_name,
 	}
 
-	print("base new annotation created")
+	log.log("Point Merge", "Base annotation created", log_level=log.DEBUG.STATUS)
 
 	for pair in source_annotations:
 		base_annotations = json_data["layers"][annotation_names.index(pair.name)]["annotations"]
 		in_order = base_annotations if pair.direction else list(reversed(base_annotations))
 		new_annotation_layer["annotations"] += in_order
 
-	print("new annotation created")
+	log.log("Point Merge", "Merged annotation created", log_level=log.DEBUG.STATUS)
 
 	json_data["layers"].append(new_annotation_layer)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Point Merge", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/point_shift.py
+++ b/ng/point_shift.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 import numpy as np
 
+from shared import log
 from shared.cli import DelimitedRecord
 
 Coord = namedtuple("Coord", ["x", "y", "z"])
@@ -24,7 +25,7 @@ def point_shift(json_file: Path, json_result: Path, shift_dimensions: Coord):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Point Shift", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	for layer in json_data["layers"]:
 		if layer["type"] == "annotation":
@@ -32,12 +33,12 @@ def point_shift(json_file: Path, json_result: Path, shift_dimensions: Coord):
 				if annotation["type"] == "point":
 					annotation["point"] = list(np.add(annotation["point"], shift_dimensions))
 
-	print("annotation updated")
+	log.log("Point Shift", "Annotations updated", log_level=log.DEBUG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Point Shift", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/point_sort.py
+++ b/ng/point_sort.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from shared import log
 from shared.cli import DelimitedRecord
 
 
@@ -34,25 +35,25 @@ def point_sort(json_file: Path, json_result: Path, axis: int, source_annotations
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Point Sort", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	annotation_names = [layer["name"] for layer in json_data["layers"]]
 
 	for pair in source_annotations:
 		if pair.name not in annotation_names:
-			print(f"Annotation {pair.name} missing.")
+			log.log("Point Sort", f"Annotation {pair.name} missing.", log_level=log.DEBUG.WARN)
 		else:
 			base_annotations = json_data["layers"][annotation_names.index(pair.name)]["annotations"]
 			sorted_annotations = sorted(base_annotations, key=lambda x: x['point'][axis])
 			final_annotations = sorted_annotations if pair.direction else reversed(sorted_annotations)
 			json_data["layers"][annotation_names.index(pair.name)]["annotations"] = list(final_annotations)
 
-	print("annotations updated")
+	log.log("Point Sort", "Annotations updated", log_level=log.DEBUG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new annotation written to {json_result}")
+	log.log("Point Sort", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/position_copy.py
+++ b/ng/position_copy.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import click
 
+from shared import log
+
 
 @click.command()
 @click.option("--json-file", "-j", type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
@@ -22,18 +24,18 @@ def position_copy(json_file, json_result, json_target):
 	with open(json_target) as json_handle:
 		json_upd = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Position Copy", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	for field in ["position", "crossSectionOrientation", "crossSectionScale",
 					"projectionOrientation", "projectionScale", "layout", "layerListPanel"]:
 		json_upd[field] = json_data[field]
 
-	print("orientation updated")
+	log.log("Position Copy", "Orientation updated", log_level=log.DEBUG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_upd, handle)
 
-	print(f"new arrangement written to {json_result}")
+	log.log("Position Copy", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/ng/shift_angle.py
+++ b/ng/shift_angle.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import click
 
+from shared import log
+
 
 @click.command()
 @click.option("--json-file", "-j", type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
@@ -21,7 +23,7 @@ def shift_angle(json_file, json_result, make_ortho):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	print("json loaded")
+	log.log("Shift Angle", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
 
 	json_data["projectionOrientation"] = [
 		0.3462526500225067,
@@ -30,7 +32,7 @@ def shift_angle(json_file, json_result, make_ortho):
 		0.8535001277923584
 	]
 
-	print("orientation updated")
+	log.log("Shift Angle", "Orientation updated", log_level=log.DEBUG.STATUS)
 
 	if make_ortho:
 		if isinstance(json_data["layout"], str):
@@ -40,12 +42,12 @@ def shift_angle(json_file, json_result, make_ortho):
 			}
 		else:
 			json_data["layout"]["orthographicProjection"] = True
-		print("Made orthographic, if not already.")
+		log.log("Shift Angle", "Made orthographic, if not already.", log_level=log.DEBUG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	print(f"new arrangement written to {json_result}")
+	log.log("Shift Angle", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/transform/find_bounds.py
+++ b/transform/find_bounds.py
@@ -7,6 +7,8 @@ import numpy as np
 import psutil
 import tifffile as tf
 
+from shared import log
+
 count = 0
 start_time = datetime.now()
 
@@ -15,7 +17,8 @@ def image_bounds(path):
 	x = tf.imread(path)
 	global count
 	count += 1
-	print(f"\r{count} Calculated {datetime.now() - start_time}", end='')
+	if count % 50 == 0:
+		log.log("Find Bounds", f"{count} calculated", log_level=log.DEBUG.INFO)
 	return np.array([np.min(x), np.max(x)])
 
 
@@ -23,12 +26,12 @@ def image_bounds(path):
 @click.option("--process-count", "-p", type=click.INT, default=psutil.cpu_count() * 3, help="")
 @click.argument("input-path", type=click.Path(file_okay=False, exists=True, path_type=Path))
 def find_bounds(process_count, input_path):
-	print("Starting")
+	log.log("Find Bounds", f"Scanning {input_path}", log_level=log.DEBUG.STATUS)
 	with ThreadPool(process_count) as pool:
 		bounds = np.array(pool.map(image_bounds, input_path.glob("**/*.tif*")))
 	min_val = np.min(bounds[:, 0])
 	max_val = np.max(bounds[:, 1])
-	print(f"\n{min_val}:{max_val}")
+	log.log("Find Bounds", f"{min_val}:{max_val}", log_level=log.DEBUG.STATUS)
 	return min_val, max_val
 
 

--- a/transform/hdf_convert.py
+++ b/transform/hdf_convert.py
@@ -6,6 +6,8 @@ import click
 from osgeo import gdal
 import tifffile
 
+from shared import log
+
 startTime = datetime.now()
 gdal.UseExceptions() 	# Throws many warnings if we don't set whether we want exceptions.
 
@@ -19,25 +21,30 @@ def get_image_paths(folder: Path):
 	return sorted(folder.glob('raw/*.hdf'))
 
 
-def image_conv(image_path: Path, target_dir: Path):
+def image_conv(image_path: Path, target_dir: Path, execute: bool = True):
 	""" Converts hdf5 file to a tiff file and writes the result in a new location.
 
 		:param image_path: Full path to an image.
 		:param target_dir: Folder to write tiff to, retaining filename (except suffix).
+		:param execute: If False, plan the conversion without reading or writing.
 	"""
-	with open(target_dir.parent.joinpath(f"{target_dir.name}.log"), "a") as log:
-		target_path = target_dir.joinpath(image_path.with_suffix(".tiff").name)
+	target_path = target_dir.joinpath(image_path.with_suffix(".tiff").name)
 
+	if not execute:
+		log.log("HDF Convert", f"Would convert {image_path} -> {target_path}", log_level=log.DEBUG.INFO)
+		return
+
+	with open(target_dir.parent.joinpath(f"{target_dir.name}.log"), "a") as logfile:
 		src_ds = gdal.Open(str(image_path))
-		print(f"{image_path} Read")
-		log.write(f"{image_path} Read\n")
+		log.log("HDF Convert", f"{image_path} read", log_level=log.DEBUG.STATUS)
+		logfile.write(f"{image_path} Read\n")
 
 		out_ds = gdal.Translate('/vsimem/in_memory_output.tif', src_ds, format='GTiff', bandList=[1])
 		out_arr = out_ds.ReadAsArray()
 
 		tifffile.imwrite(target_path, out_arr)
-		print(f"{target_path} Written")
-		log.write(f"{target_path} Written\n")
+		log.log("HDF Convert", f"{target_path} written", log_level=log.DEBUG.STATUS)
+		logfile.write(f"{target_path} Written\n")
 
 
 @click.command()
@@ -45,9 +52,11 @@ def image_conv(image_path: Path, target_dir: Path):
 				help="Target directory to write to, defaulting to current working directory.")
 @click.option("--processes", "-p", default=60, type=click.INT,
 				help="Number of simulatenous processes to use for reading, default 60.  If 1, it will not use multiprocessing.")
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually run the conversions or just plan the work.")
 @click.argument("input", nargs=-1,
 				type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True, path_type=Path))
-def hdf_convert(target_dir, processes, input):
+def hdf_convert(target_dir, processes, execute, input):
 	""" Converts files from hdf format to tiff files, usually for hdf4.
 
 		Files are searched for in INPUT/raw/;  any number of INPUT directories are allowed."""
@@ -56,24 +65,30 @@ def hdf_convert(target_dir, processes, input):
 		total = len(file_paths)
 
 		if total == 0:
-			print(f"{proj_dir}: No images found, skipping.")
+			log.log("HDF Convert", f"{proj_dir}: No images found, skipping.", log_level=log.DEBUG.WARN)
 			continue
 		else:
 			target_subdir = target_dir.joinpath("tiff_sets", proj_dir.parent.name, proj_dir.name)
-			print(f"{proj_dir}: {total} images found; writing to {target_subdir}")
-			target_subdir.mkdir(parents=True, exist_ok=True)
+			log.log("HDF Convert",
+					f"{proj_dir}: {total} images found; writing to {target_subdir}",
+					log_level=log.DEBUG.STATUS)
+			if execute:
+				target_subdir.mkdir(parents=True, exist_ok=True)
 
-		with open(target_subdir.parent.joinpath(f"{target_subdir.name}.log"), "a") as log:
-			log.write(f"{proj_dir}: {total} images found; writing to {target_subdir}\n")
+		if execute:
+			with open(target_subdir.parent.joinpath(f"{target_subdir.name}.log"), "a") as logfile:
+				logfile.write(f"{proj_dir}: {total} images found; writing to {target_subdir}\n")
 
-		if processes == 1:
+		if processes == 1 or not execute:
 			for image_path in file_paths:
-				image_conv(image_path, target_dir)
+				image_conv(image_path, target_subdir, execute=execute)
 		else:
 			with Pool(processes=processes) as pool:
-				pool.starmap(image_conv, [(file_path, target_subdir) for file_path in file_paths])
+				pool.starmap(image_conv, [(file_path, target_subdir, execute) for file_path in file_paths])
 
-	print(f"HDF Convert Complete: {datetime.now() - startTime}")
+	log.log("HDF Convert",
+			f"HDF Convert {'complete' if execute else 'planned'}: {datetime.now() - startTime}",
+			log_level=log.DEBUG.STATUS)
 
 
 if __name__ == '__main__':

--- a/transform/ng.py
+++ b/transform/ng.py
@@ -9,6 +9,8 @@ import json
 import tifffile
 import click
 
+from shared import log
+
 
 @click.command()
 @click.option('-c', '--chunk-size', type=click.INT, show_default=True, default=128,
@@ -27,14 +29,14 @@ import click
 @click.option('-o', '--output-location', type=click.Path(), required=True)
 def neuroglance(chunk_size, resolution, segmentation, strip_gz, input_path, metadata_info, compress_info,
 				output_location):
-	print(f'input folder: {input_path}')
+	log.log("Neuroglance", f"Input folder: {input_path}", log_level=log.DEBUG.STATUS)
 	image_paths = natsorted(Path(input_path).glob("**/*.tif*"))
 
 	memmap_ = tifffile.memmap(image_paths[0])
 	size = [memmap_.shape[1], memmap_.shape[0], len(image_paths)]
 	dtype_ = str(memmap_.dtype)
 
-	print(f'volume size is :{size} datatype is {dtype_}')
+	log.log("Neuroglance", f"Volume size is {size}, datatype is {dtype_}", log_level=log.DEBUG.STATUS)
 
 	if segmentation:
 		json_metadata = {

--- a/transform/quickgunzip.py
+++ b/transform/quickgunzip.py
@@ -5,6 +5,8 @@ import shutil
 import brotli
 import click
 
+from shared import log
+
 
 @click.command()
 @click.argument("root_path", type=click.Path(exists=True))
@@ -24,7 +26,7 @@ def gunzip(root_path, target_path):
 				else:
 					shutil.copy(fname, target_file)
 			except BaseException:
-				print(f"Failed File: {fname}|{target_file}")
+				log.log("Quick Gunzip", f"Failed file: {fname}|{target_file}", log_level=log.DEBUG.ERROR)
 
 
 if __name__ == '__main__':

--- a/transform/simple_noise.py
+++ b/transform/simple_noise.py
@@ -7,9 +7,11 @@ import numpy as np
 import psutil
 import tifffile as tf
 
+from shared import log
+
 
 def denoise_threshold(input_paths, output_path, threshold):
-	print(input_paths)
+	log.log("Simple Denoise", f"Threshold inputs: {input_paths}", log_level=log.DEBUG.INFO)
 	base_data = np.array([tf.imread(infile) for infile in input_paths]).astype(np.int32)
 
 	floor = np.min(base_data)
@@ -50,11 +52,11 @@ def simple_denoise(threshold, area, num_processes, flat_denoise, inputdir, outpu
 
 	with Pool(num_processes) as pool:
 		if flat_denoise:
-			print("flat")
+			log.log("Simple Denoise", "Mode: flat", log_level=log.DEBUG.STATUS)
 			pool.starmap(denoise_flat, [(input_paths[i - 1: i + 2], outputdir.joinpath(input_paths[i].name), threshold)
 										for i in range(1, len(input_paths) - 1)])
 		else:
-			print(f"threshold {len(input_paths)}")
+			log.log("Simple Denoise", f"Mode: threshold ({len(input_paths)} inputs)", log_level=log.DEBUG.STATUS)
 			pool.starmap(denoise_threshold, [(input_paths[i - 1: i + 2], outputdir.joinpath(input_paths[i].name), threshold)
 											for i in range(1, len(input_paths) - 1)])
 

--- a/transform/uncompress.py
+++ b/transform/uncompress.py
@@ -4,14 +4,28 @@ import click
 from natsort import natsorted
 import tifffile as tf
 
+from shared import log
+
+
 @click.command()
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually rewrite the files or just plan the rewrites.")
 @click.argument("image_path", type=click.Path(exists=True, file_okay=False, writable=True, path_type=Path))
-def uncompress(image_path: Path):
+def uncompress(execute: bool, image_path: Path):
+	""" Rewrite every TIFF under IMAGE_PATH with compression removed.
+
+		With --dry-run, lists which files would be rewritten without touching them.
+	"""
 	images = natsorted(image_path.glob("*.tif*"))
 	for im_path in images:
-		image = tf.imread(im_path)
-		tf.imwrite(im_path, image, compression=None)
-		print(f"Rewrote {im_path}")
+		if execute:
+			image = tf.imread(im_path)
+			tf.imwrite(im_path, image, compression=None)
+			log.log("Uncompress", f"Rewrote {im_path}", log_level=log.DEBUG.STATUS)
+		else:
+			log.log("Uncompress", f"Would rewrite {im_path}", log_level=log.DEBUG.INFO)
+	log.log("Uncompress", f"{len(images)} files {'rewritten' if execute else 'planned'}", log_level=log.DEBUG.STATUS)
+
 
 if __name__ == "__main__":
 	uncompress()


### PR DESCRIPTION
## Summary

Stacked on #54.

- Repo-wide `print()` -> `shared.log.log` cleanup across the ng/ annotation tools (point_shift, point_sort, point_merge, layer_tag, layer_copy, layer_extract, layer_urlshift, point_add, position_copy, shift_angle, change_color) and the transform/ informational outputs (find_bounds, quickgunzip, simple_noise, ng, hdf_convert, uncompress).
- `--execute` / `--dry-run` added to `transform.uncompress` (CLI: `transform decompress-tiff`) and `transform.hdf_convert` (CLI: `transform hdf-convert`), matching the trim / normalize / sinogram pattern from #54.
- Drive-by: the serial `hdf_convert` path now writes to the per-projection `target_subdir` instead of the top-level `target_dir`, fixing a divergence with the multiprocess path.
- `find_bounds` per-image counter is now a periodic log line every 50 images instead of an in-place `\r` print that was already racey under `ThreadPool.map`.

## Test plan

- [x] `flake8 --extend-ignore=C901` on the changed surfaces
- [x] `python scripts/check_python_tabs.py`
- [x] `pytest tests -q` (70 passed)
- [x] `mctutil --help` plus per-command `--help` on every touched subcommand
- [x] `transform decompress-tiff --dry-run` smoke-tested end-to-end: files are listed as "Would rewrite" with no mtime change, then `--execute` rewrites them