### PR TITLE
Phase 5 finish: complete print->log + dry-run coverage

### DIFF
--- a/hpc_work/timecheck.py
+++ b/hpc_work/timecheck.py
@@ -1,7 +1,15 @@
 from datetime import datetime, timedelta
 from os import walk
 from pathlib import Path
+import sys
+
 import click
+
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
+
 
 @click.command()
 @click.option("--scan_root", type=click.Path(), required=True, help="Root to search for projection start/stop from images.")
@@ -23,9 +31,11 @@ def timecheck(scan_root):
 					projection_size = Path(root, files[-1]).stat().st_size / 1000000
 					scandatalist.append(f"{scan_start},{scan_start+scan_duration},{base.parent.parent.name},{base.parent.name},{'_'.join(base.name.split('_')[3:-1])},{projection_size:.1f}MB")
 				except Exception as ex:
-					print(ex)
+					log.log("Time Check", f"{ex}", log_level=log.DEBUG.ERROR)
 	scandatalist.sort()
 	for line in scandatalist:
-		print(line)
+		log.log("Time Check", line, log_level=log.DEBUG.INFO)
+
+
 if __name__ == '__main__':
 	timecheck()

--- a/mctutil/parse/__init__.py
+++ b/mctutil/parse/__init__.py
@@ -7,6 +7,7 @@ main = LazyGroup(
 	help="Metadata, config, and scanlog parsing helpers.",
 	lazy_subcommands={
 		"meta-shift": "parsing.meta_shift:meta_shift",
+		"prune-empty": "parsing.empty_dir_removal:prune_empty",
 		"pull-config": "parsing.pull_config:get_conf",
 		"scanlog-fetch": "parsing.scanlog_fetch:scanlog_fetch",
 	},

--- a/mem/clean.py
+++ b/mem/clean.py
@@ -2,10 +2,16 @@ from enum import IntEnum
 from multiprocessing import shared_memory
 from io import StringIO
 from pathlib import Path
+import sys
 from subprocess import run, PIPE
 
 import click
 import ipyslurm
+
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
 
 # Names of shared memory to be script-specific (for now)
 shm = {
@@ -56,7 +62,8 @@ def mem_clean(shared_base, apply, apply_kmp):
 					clean_target = shared_memory.SharedMemory(name=mem_name)
 					clean_target.close()
 					clean_target.unlink()
-				print(f"{host}:{mem_name}:{apply}")
+				log.log("Mem Clean", f"{host}:{mem_name}:{apply}",
+						log_level=log.DEBUG.STATUS if apply else log.DEBUG.INFO)
 			elif mem_name[:len(other_shm)] == other_shm:
 				if apply_kmp:
 					try:
@@ -65,7 +72,8 @@ def mem_clean(shared_base, apply, apply_kmp):
 						clean_target.unlink()
 					except FileNotFoundError:
 						pass
-					print(f"{host}:{mem_name}:{apply}")
+					log.log("Mem Clean", f"{host}:{mem_name}:{apply}",
+							log_level=log.DEBUG.STATUS if apply else log.DEBUG.INFO)
 
 
 @click.group()
@@ -140,7 +148,7 @@ python -X pycache_prefix=~/.pycache ~/mem/clean.py {param_str} clean
 			'--partition', partition,
 			'--nodes', str(len(nodes))
 ])
-			print(f"Job {partition}:{res}")
+			log.log("Mem Clean", f"Job {partition}:{res}", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mem/from_file.py
+++ b/mem/from_file.py
@@ -1,7 +1,13 @@
 from pathlib import Path
+import sys
 from subprocess import run
 
 import click
+
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
 
 
 def collect_idle_nodes(node_file: Path):
@@ -21,10 +27,16 @@ def collect_idle_nodes(node_file: Path):
 @click.command()
 @click.option("--sbatch-script", type=click.Path(path_type=Path), required=True,
 				help="Sbatch script to submit for each selected node.")
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually submit sbatch jobs or just list the planned submissions.")
 @click.argument("node_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))
-def from_file(sbatch_script: Path, node_file: Path):
+def from_file(sbatch_script: Path, execute: bool, node_file: Path):
 	for node in collect_idle_nodes(node_file):
-		run(["sbatch", "-w", node, str(sbatch_script)])
+		if execute:
+			run(["sbatch", "-w", node, str(sbatch_script)])
+			log.log("Mem From File", f"sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.STATUS)
+		else:
+			log.log("Mem From File", f"Would sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.INFO)
 
 
 if __name__ == "__main__":

--- a/mem/from_range.py
+++ b/mem/from_range.py
@@ -1,6 +1,13 @@
+from pathlib import Path
+import sys
 from subprocess import run
 
 import click
+
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
 
 
 def expand_node_range(prefix: str, start: int, stop: int):
@@ -12,9 +19,15 @@ def expand_node_range(prefix: str, start: int, stop: int):
 @click.option("--start", type=click.INT, required=True)
 @click.option("--stop", type=click.INT, required=True)
 @click.option("--sbatch-script", type=click.STRING, default="memclean.sbatch", show_default=True)
-def from_range(prefix: str, start: int, stop: int, sbatch_script: str):
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually submit sbatch jobs or just list the planned submissions.")
+def from_range(prefix: str, start: int, stop: int, sbatch_script: str, execute: bool):
 	for node in expand_node_range(prefix, start, stop):
-		run(["sbatch", "-w", node, sbatch_script])
+		if execute:
+			run(["sbatch", "-w", node, sbatch_script])
+			log.log("Mem From Range", f"sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.STATUS)
+		else:
+			log.log("Mem From Range", f"Would sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.INFO)
 
 
 if __name__ == "__main__":

--- a/parsing/empty_dir_removal.py
+++ b/parsing/empty_dir_removal.py
@@ -1,11 +1,34 @@
 from pathlib import Path
+import sys
 
-drive = Path("/gpfs/Labs/Cheng/phenome/")
+import click
 
-history_list = list(drive.rglob("*history"))
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-for history in history_list:
-	for inner_dir in history.iterdir():
-		if not bool(len(list(inner_dir.iterdir()))):
-			print(f"Removing Empty {inner_dir}")
-			inner_dir.rmdir()
+from shared import log 	# noqa::E402
+
+
+@click.command()
+@click.option("--pattern", type=click.STRING, default="*history", show_default=True,
+				help="rglob pattern under ROOT for directories whose immediate children should be pruned.")
+@click.option('--execute/--dry-run', default=False, show_default=True,
+				help="Whether to actually rmdir empty directories or just list them. Defaults to dry-run.")
+@click.argument("root", type=click.Path(exists=True, file_okay=False, path_type=Path))
+def prune_empty(pattern: str, execute: bool, root: Path):
+	""" Remove empty subdirectories under each match of PATTERN beneath ROOT.
+
+		Defaults to dry-run because the operation is destructive.
+	"""
+	for outer in root.rglob(pattern):
+		for inner_dir in outer.iterdir():
+			if inner_dir.is_dir() and not any(inner_dir.iterdir()):
+				if execute:
+					log.log("Prune Empty", f"Removing empty {inner_dir}", log_level=log.DEBUG.STATUS)
+					inner_dir.rmdir()
+				else:
+					log.log("Prune Empty", f"Would remove empty {inner_dir}", log_level=log.DEBUG.INFO)
+
+
+if __name__ == "__main__":
+	prune_empty()

--- a/parsing/pull_config.py
+++ b/parsing/pull_config.py
@@ -1,18 +1,34 @@
 from pathlib import Path
+import sys
 from shutil import copy
 
 import click
+
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
 
 
 @click.command()
 @click.option("--source", type=click.Path(exists=True), help="Root Directory to Search for Configs.")
 @click.option("--target", type=click.Path(exists=False), help="Target Directory to Place Copied Configs.")
-def get_conf(source, target):
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually copy configs or just list the planned copies.")
+def get_conf(source, target, execute):
 	source_conf_set = Path(source).glob("**/*.yaml")
-	Path(target).mkdir(exist_ok=True, parents=True)
+	if execute:
+		Path(target).mkdir(exist_ok=True, parents=True)
+	else:
+		log.log("Pull Config", f"Would create {target}", log_level=log.DEBUG.INFO)
 	for conf in source_conf_set:
-		print(f"{conf.parent.name}_{conf.name}")
-		copy(conf, Path(target, f"{conf.parent.name}_{conf.name}"))
+		dest = Path(target, f"{conf.parent.name}_{conf.name}")
+		if execute:
+			log.log("Pull Config", f"{conf.parent.name}_{conf.name}", log_level=log.DEBUG.STATUS)
+			copy(conf, dest)
+		else:
+			log.log("Pull Config", f"Would copy {conf} -> {dest}", log_level=log.DEBUG.INFO)
+
 
 if __name__ == "__main__":
 	get_conf()

--- a/parsing/scanlog_fetch.py
+++ b/parsing/scanlog_fetch.py
@@ -1,20 +1,38 @@
 from pathlib import Path
+import sys
 from shutil import copy
 
 import click
 
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
+
 
 @click.command()
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually copy scanlogs or just list the planned copies.")
 @click.argument("root_dir", nargs=-1, type=click.Path())
-def scanlog_fetch(root_dir):
-	Path("logs").mkdir(exist_ok=True)
+def scanlog_fetch(execute, root_dir):
+	if execute:
+		Path("logs").mkdir(exist_ok=True)
+	else:
+		log.log("Scanlog Fetch", "Would create logs/", log_level=log.DEBUG.INFO)
 	for dir_name in root_dir:
 		for fullpath in Path(dir_name).rglob("scanlog.txt"):
 			software_trigger_scans = ["_post", "_pre", "_uncrop", "_crop", "_focus", "_step"]
 			if not any(stscan in fullpath.parent.name.lower() for stscan in software_trigger_scans):
 				if fullpath.stat().st_size > 93:
-					copy(fullpath, Path("logs", f"{fullpath.parent.name}_scanlog.txt"))
-					click.echo(f"{fullpath.parent.name}:{fullpath.stat().st_size}")
+					target = Path("logs", f"{fullpath.parent.name}_scanlog.txt")
+					if execute:
+						copy(fullpath, target)
+						log.log("Scanlog Fetch", f"{fullpath.parent.name}:{fullpath.stat().st_size}",
+								log_level=log.DEBUG.STATUS)
+					else:
+						log.log("Scanlog Fetch",
+								f"Would copy {fullpath} -> {target} (size {fullpath.stat().st_size})",
+								log_level=log.DEBUG.INFO)
 
 
 if __name__ == "__main__":

--- a/tests/test_phase1_regressions.py
+++ b/tests/test_phase1_regressions.py
@@ -68,7 +68,7 @@ def test_df_write_tiff_uses_source_title_for_output_name(load_module, monkeypatc
 	monkeypatch.setattr(module, "orsObj", lambda *_args, **_kwargs: source)
 	monkeypatch.setattr(module.tf, "imwrite", lambda path, data: written.update(path=Path(path), data=data.copy()))
 
-	module.df_write_tiff.callback(source_path, None, None, "dummy-id", output_dir)
+	module.df_write_tiff.callback(source_path, None, None, "dummy-id", True, output_dir)
 
 	assert written["path"].name == "roi-title.tif"
 	assert written["path"].parent == output_dir
@@ -104,7 +104,7 @@ def test_s3upload_does_not_require_client_close(load_module, monkeypatch, tmp_pa
 	monkeypatch.setattr(module, "session", DummySession())
 	monkeypatch.setattr(module, "upload_folder_to_s3_parallel", lambda *_args, **_kwargs: None)
 
-	module.s3upload.callback(Path("prefix"), "bucket", 4, False, source_dir, Path("target"))
+	module.s3upload.callback(Path("prefix"), "bucket", 4, False, True, source_dir, Path("target"))
 
 	assert client_calls == [{"Bucket": "bucket", "Key": "prefix/target/"}]
 

--- a/transform/channelize.py
+++ b/transform/channelize.py
@@ -12,7 +12,12 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from shared import log 	# noqa::E402
 
 
-def channelize_file(randomize, source, target_dir):
+def channelize_file(randomize, source, target_dir, execute=True):
+	target_path = target_dir.joinpath(source.name)
+	if not execute:
+		log.log("Channelize", f"Would write {target_path}", log_level=log.DEBUG.INFO)
+		return
+
 	source_data = tf.imread(source)
 
 	if (len(source_data.shape) > 2 and source_data.shape[-1] == 1):
@@ -29,20 +34,24 @@ def channelize_file(randomize, source, target_dir):
 	else:
 		target_data = np.repeat(source_data, 3).reshape(new_shape)
 
-	# print(f"{source}|{source_data.shape}|{target_data.shape}|{target_path.joinpath(source.name)}")
-
-	tf.imwrite(target_dir.joinpath(source.name), target_data.astype(source_data.dtype))
-	log.log("Write Target", f"{target_dir.joinpath(source.name)} Written")
+	tf.imwrite(target_path, target_data.astype(source_data.dtype))
+	log.log("Channelize", f"{target_path} written", log_level=log.DEBUG.STATUS)
 
 
 @click.command()
 @click.option("--randomize", is_flag=True)
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually write channelized TIFFs or just plan the writes.")
 @click.argument("root_path", type=click.Path(exists=True, path_type=Path))
 @click.argument("target_path", type=click.Path(exists=False, path_type=Path))
-def channelize(randomize, root_path, target_path):
-	target_path.mkdir(parents=True)
+def channelize(randomize, execute, root_path, target_path):
+	if execute:
+		target_path.mkdir(parents=True)
+	else:
+		log.log("Channelize", f"Would create {target_path}", log_level=log.DEBUG.INFO)
 	with Pool(12) as pool:
-		pool.starmap(channelize_file, [(randomize, source, target_path) for source in root_path.iterdir()])
+		pool.starmap(channelize_file,
+					[(randomize, source, target_path, execute) for source in root_path.iterdir()])
 
 
 if __name__ == '__main__':

--- a/transform/df_write_tiff.py
+++ b/transform/df_write_tiff.py
@@ -2,6 +2,11 @@ import os
 from pathlib import Path
 import sys
 
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
+
 
 def _env_path(name: str, default: str) -> Path:
 	return Path(os.environ.get(name, default))
@@ -27,7 +32,7 @@ def set_df_environment():
 		ana_dir.joinpath("Lib\\site-packages\\pywin32_system32"),
 		ors_dir.joinpath("pythonAllUsersExtensions"), user_dir.joinpath("pythonUserExtensions")]])
 
-	print('Python %s on %s' % (sys.version, sys.platform), flush=True)
+	log.log("DF Write TIFF", f"Python {sys.version} on {sys.platform}", log_level=log.DEBUG.INFO)
 
 
 set_df_environment()
@@ -43,8 +48,10 @@ import tifffile as tf 	# noqa:E402
 @click.option("-o", "--df-object", type=click.STRING, help="Type of object to output, if done by class and title.")
 @click.option("-t", "--df-title", type=click.STRING, help="Title of object to output, if done by class and title.")
 @click.option("-i", "--df-id", type=click.STRING, help="ID of object to output, if done by id.")
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually write the TIFF or just describe the planned write.")
 @click.argument("OUTPUTDIR", type=click.Path(exists=False, writable=True, dir_okay=True, path_type=Path))
-def df_write_tiff(df_source, df_object, df_title, df_id, outputdir):
+def df_write_tiff(df_source, df_object, df_title, df_id, execute, outputdir):
 	roi_set = List()
 	roi_set.loadFromFileFiltered(df_source, False, ['CxvLabeledMultiROI'], Progress())
 
@@ -53,7 +60,12 @@ def df_write_tiff(df_source, df_object, df_title, df_id, outputdir):
 	else:
 		source = orsObj(df_id)
 
-	tf.imwrite(outputdir.joinpath(f"{source.getTitle()}.tif"), source.getAsNDArray(0))
+	target = outputdir.joinpath(f"{source.getTitle()}.tif")
+	if execute:
+		tf.imwrite(target, source.getAsNDArray(0))
+		log.log("DF Write TIFF", f"Wrote {target}", log_level=log.DEBUG.STATUS)
+	else:
+		log.log("DF Write TIFF", f"Would write {target}", log_level=log.DEBUG.INFO)
 
 
 if __name__ == "__main__":

--- a/transform/mesh.py
+++ b/transform/mesh.py
@@ -2,20 +2,33 @@
 Supported Formats: None (precomputed), graphene, precomputed, boss, n5
 Supported Protocols: gs, file, s3, http, https, mem, matrix, tigerdata
 '''
+from pathlib import Path
+import sys
+
 from taskqueue import LocalTaskQueue
 import click
 
 import igneous.task_creation as tc
 
-# layer_path = os.path.join(proj_dir, '33dpf_seg_test')
-# layer_path = 'precomputed://s3://3d.fish/assets/precomputed_repository/B2_daphnia/AAA399/AAA399_seg_out/'
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
 
 
 @click.command()
 @click.option("-p", "--proj-dir", type=click.Path(file_okay=False), required=True, help="Path of input data.")
 @click.option("-l", "--layer-path", type=click.STRING, required=True, help="Path of Layer data, including remote URLs.")
-def mesh(proj_dir, layer_path):
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually enqueue meshing tasks or just describe the planned passes.")
+def mesh(proj_dir, layer_path, execute):
 	mip = 0
+
+	if not execute:
+		log.log("Mesh",
+				f"Would create meshing tasks for {layer_path} (mip={mip}, shape=512^3) and follow with manifest tasks",
+				log_level=log.DEBUG.INFO)
+		return
 
 	with LocalTaskQueue(parallel=8) as tq:
 		tasks = tc.create_meshing_tasks( 	# First Pass
@@ -35,13 +48,13 @@ def mesh(proj_dir, layer_path):
 			sharded=False,					# generate intermediate shard fragments for later processing into sharded format
 		)
 		tq.insert_all(tasks)
-	print("Done create_meshing_tasks !!")
+	log.log("Mesh", "create_meshing_tasks complete", log_level=log.DEBUG.STATUS)
 
 	with LocalTaskQueue(parallel=8) as tq:
 		tasks = tc.create_mesh_manifest_tasks(layer_path, magnitude=3) 	# Second Pass
 		tq.insert_all(tasks)
 
-	print("Done create_mesh_manifest_tasks !!")
+	log.log("Mesh", "create_mesh_manifest_tasks complete", log_level=log.DEBUG.STATUS)
 
 
 if __name__ == "__main__":

--- a/transform/stitch.py
+++ b/transform/stitch.py
@@ -98,7 +98,12 @@ class SampleSet():
 		self._flat_mem.unlink()
 
 
-def stitch_single(samples, overlaps, new_dim, stitch_output, x):
+def stitch_single(samples, overlaps, new_dim, stitch_output, x, execute=True):
+	output_path = Path(stitch_output, f"AAA590_Stitched_{x}.tif")
+	if not execute:
+		log.log("Stitch", f"Would write {output_path}", log_level=log.DEBUG.INFO)
+		return
+
 	stitched = np.zeros(new_dim, dtype=np.uint16)
 
 	for s in samples:
@@ -109,7 +114,6 @@ def stitch_single(samples, overlaps, new_dim, stitch_output, x):
 
 	for i, overlap in enumerate(overlaps):
 		non_overlap = samples[i + 1].proj.shape[0] - overlap
-		# print(f"{offset}|{overlap}|{non_overlap}")
 
 		# Proj Merge
 		stitched[offset - overlap:offset, :] = np.median(
@@ -120,10 +124,10 @@ def stitch_single(samples, overlaps, new_dim, stitch_output, x):
 
 		offset += non_overlap
 
-	tf.imwrite(Path(stitch_output, f"AAA590_Stitched_{x}.tif"), stitched)
+	tf.imwrite(output_path, stitched)
 
 
-def stitch_samples(samples, overlaps, stitch_output):
+def stitch_samples(samples, overlaps, stitch_output, execute=True):
 	new_dim = (np.sum([s.proj.shape[0] for s in samples]) - np.sum(overlaps), samples[0].half_width * 2)
 
 	for s in samples:
@@ -131,14 +135,20 @@ def stitch_samples(samples, overlaps, stitch_output):
 
 	log.log("Dimension", new_dim)
 
-	Path(stitch_output).mkdir(parents=True, exist_ok=True)
+	if execute:
+		Path(stitch_output).mkdir(parents=True, exist_ok=True)
+	else:
+		log.log("Stitch", f"Would create {stitch_output}", log_level=log.DEBUG.INFO)
 
 	log.log("Output Dir", stitch_output)
 
 	with Pool(50) as pool:
-		pool.starmap(stitch_single, [(samples, overlaps, new_dim, stitch_output, x) for x in range(len(samples[0].projs))])
+		pool.starmap(stitch_single,
+					[(samples, overlaps, new_dim, stitch_output, x, execute)
+						for x in range(len(samples[0].projs))])
 
-	log.log("Stitching Complete", f"{len(samples[0].projs)} Projections Stitched")
+	log.log("Stitching Complete",
+			f"{len(samples[0].projs)} projections {'stitched' if execute else 'planned'}")
 
 
 @click.command()
@@ -150,8 +160,9 @@ def stitch_samples(samples, overlaps, stitch_output):
 @click.option("--stitch-range", type=click.FLOAT, default=0.2,
 				help="Maximum range (as percent of height) to scan for overlaps.")
 @click.option("--stitch-output", type=click.Path(), required=True, help="Output path of stitching.")
-def stitch(sample, top_stitch, stitch_range, stitch_output):
-	# samples = [SampleSet(first_sample, first_flat, first_center), SampleSet(second_sample, second_flat, second_center)]
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually write stitched output or just plan the writes.")
+def stitch(sample, top_stitch, stitch_range, stitch_output, execute):
 	target_width = min([x.half_width for x in sample])
 
 	for s in sample:
@@ -173,7 +184,7 @@ def stitch(sample, top_stitch, stitch_range, stitch_output):
 
 		overlaps.append(std_set[0][0])
 
-	stitch_samples(sample, overlaps, stitch_output)
+	stitch_samples(sample, overlaps, stitch_output, execute=execute)
 
 	for s in sample:
 		s.unlink()

--- a/transport/cv_import.py
+++ b/transport/cv_import.py
@@ -18,8 +18,13 @@ from shared import log 	# noqa::E402
 from shared import cli 	# noqa::E402
 
 
-def fetch_slices(remote, use_https, region, bin_power, output_dir):
+def fetch_slices(remote, use_https, region, bin_power, output_dir, execute=True):
 	log.log("Fetching Slices", f"{remote}: {region} with {bin_power}")
+	if not execute:
+		log.log("Fetching Slices",
+				f"Would fetch slices {region[0].start}..{region[0].stop} to {output_dir}",
+				log_level=log.DEBUG.INFO)
+		return
 	vol = CloudVolume(remote, mip=bin_power, use_https=use_https, progress=True)
 	for i, slice_data in enumerate(vol[region], start=region[0].start):
 		tifffile.imwrite(os.path.join(output_dir, f"slice_{str(i).zfill(4)}.tif"), slice_data)
@@ -49,8 +54,10 @@ def bin_slices(base_slice, bin_power, base_dim):
 @click.option("--use-https", is_flag=True, help="Whether to use an https connection.")
 @click.option("-n", "--num-processes", type=click.INT, default=psutil.cpu_count(),
 				help="Number of simultaneous processes.")
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually fetch and write slices or just plan the work.")
 @click.argument("output-dir")
-def cloudvolume_fetch(cloud_url, cloud_slice, resolution, bin_power, use_https, num_processes, output_dir):
+def cloudvolume_fetch(cloud_url, cloud_slice, resolution, bin_power, use_https, num_processes, execute, output_dir):
 	log.log("Start")
 
 	cloud_slice = bin_slices(cloud_slice, bin_power,
@@ -59,12 +66,15 @@ def cloudvolume_fetch(cloud_url, cloud_slice, resolution, bin_power, use_https, 
 
 	# directory management
 	output_dir = Path(output_dir, f'CV_bin{bin_power}_{resolution*2**bin_power}um_{datetime.now().strftime("%Y_%m_%d-%I_%M_%S_%p")}')
-	output_dir.mkdir(parents=True, exist_ok=True)
+	if execute:
+		output_dir.mkdir(parents=True, exist_ok=True)
+	else:
+		log.log("Cloudvolume Fetch", f"Would create {output_dir}", log_level=log.DEBUG.INFO)
 
 	with Pool(num_processes) as pool:
 		pool.starmap(fetch_slices,
 			[(cloud_url, use_https, (np.s_[i:min(i + batch_size, cloud_slice[0].stop)],) + cloud_slice[1:],
-				bin_power, output_dir) for i in range(cloud_slice[0].start, cloud_slice[0].stop, batch_size)])
+				bin_power, output_dir, execute) for i in range(cloud_slice[0].start, cloud_slice[0].stop, batch_size)])
 
 	log.log("Complete")
 

--- a/transport/s3upload.py
+++ b/transport/s3upload.py
@@ -18,15 +18,19 @@ from shared import log 	# noqa::E402
 session = boto3.Session(profile_name='chenglab')
 
 
-def upload_file_to_s3(file_path, key, bucket_name, content_encoding):
+def upload_file_to_s3(file_path, key, bucket_name, content_encoding, execute=True):
+	if not execute:
+		log.log("S3 Upload", f"Would upload {file_path} -> s3://{bucket_name}/{key}", log_level=log.DEBUG.INFO)
+		return
+
 	s3 = session.client('s3')
 	if file_path.is_dir():  # Handle directory
 		try:
 			s3.put_object(Bucket=bucket_name, Key=f"{key}/")
 		except ClientError as e:
-			print(e.response)
+			log.log("S3 Upload", f"ClientError: {e.response}", log_level=log.DEBUG.ERROR)
 		except Exception as e:
-			print(e)
+			log.log("S3 Upload", f"{e}", log_level=log.DEBUG.ERROR)
 	else:  # Handle file
 		extra_args = {}
 		if content_encoding is not None:
@@ -34,54 +38,62 @@ def upload_file_to_s3(file_path, key, bucket_name, content_encoding):
 		try:
 			s3.upload_file(file_path, bucket_name, str(key), ExtraArgs=extra_args)
 		except ClientError as e:
-			print(e.response)
+			log.log("S3 Upload", f"ClientError: {e.response}", log_level=log.DEBUG.ERROR)
 		except Exception as e:
-			print(e)
-	print(f'uploaded: {key}')
+			log.log("S3 Upload", f"{e}", log_level=log.DEBUG.ERROR)
+	log.log("S3 Upload", f"uploaded: {key}", log_level=log.DEBUG.STATUS)
 
 
-def upload_folder_to_s3_parallel(folder_path, target_folder, bucket_name, num_processes):
+def upload_folder_to_s3_parallel(folder_path, target_folder, bucket_name, num_processes, execute=True):
 	with ProcessPoolExecutor(max_workers=num_processes) as executor:
 		for root, dirs, files in os.walk(str(folder_path)):
 			for dir_name in dirs:
 				dir_path = Path(root).joinpath(dir_name)
 				key = target_folder.joinpath(dir_path.relative_to(folder_path))
-				executor.submit(upload_file_to_s3, dir_path, key, bucket_name, None)
+				executor.submit(upload_file_to_s3, dir_path, key, bucket_name, None, execute)
 			for file_name in files:
 				file_path = Path(root).joinpath(file_name)
 				key = target_folder.joinpath(file_path.relative_to(folder_path))
 				content_encoding = 'gzip' if file_name != 'info' else None
-				executor.submit(upload_file_to_s3, file_path, key, bucket_name, content_encoding)
+				executor.submit(upload_file_to_s3, file_path, key, bucket_name, content_encoding, execute)
 
 
 @click.command()
 @click.option("-p", "--bucket-prefix", type=click.Path(path_type=Path), required=True)
 @click.option("-n", "--bucket-name", type=click.STRING, required=True, help="Name of target s3 bucket.")
 @click.option("-t", "--process-count", type=click.INT, default=60, help="Number of simultaneous uploads.")
-@click.option("--mesh", type=click.BOOL, is_flag=True, show_default=True, default=False, 
+@click.option("--mesh", type=click.BOOL, is_flag=True, show_default=True, default=False,
 				help="Whether to mesh the resulting upload.")
+@click.option('--execute/--dry-run', default=True,
+				help="Whether to actually upload (and optionally mesh) or just plan the operations.")
 @click.argument("SOURCE_FOLDER", nargs=1, type=click.Path(exists=True, path_type=Path))
 @click.argument("TARGET_FOLDER", nargs=1, type=click.Path(path_type=Path))
-def s3upload(bucket_prefix, bucket_name, process_count, mesh, source_folder, target_folder):
+def s3upload(bucket_prefix, bucket_name, process_count, mesh, execute, source_folder, target_folder):
 
 	target_full = bucket_prefix.joinpath(target_folder)
 
-	print(f'target bucket: {bucket_name}')
-	print(f'target folder: {target_full}')
+	log.log("S3 Upload", f"target bucket: {bucket_name}", log_level=log.DEBUG.STATUS)
+	log.log("S3 Upload", f"target folder: {target_full}", log_level=log.DEBUG.STATUS)
 
-	s3 = session.client('s3')
-	s3.put_object(Bucket=bucket_name, Key=f"{target_full}/")
+	if execute:
+		s3 = session.client('s3')
+		s3.put_object(Bucket=bucket_name, Key=f"{target_full}/")
+	else:
+		log.log("S3 Upload", f"Would create prefix s3://{bucket_name}/{target_full}/", log_level=log.DEBUG.INFO)
 
-	upload_folder_to_s3_parallel(source_folder, target_full, bucket_name, num_processes=process_count)
+	upload_folder_to_s3_parallel(source_folder, target_full, bucket_name, num_processes=process_count, execute=execute)
 
 	if mesh:
 		mesh_path = f"precomputed://s3://{bucket_name}/{target_full}"
-		print(f"full remote path: {mesh_path}")
-		tq = LocalTaskQueue(parallel=process_count // 4)
-		tq.insert(tc.create_meshing_tasks(mesh_path, mip=0))
-		tq.execute()
-		tq.insert(tc.create_unsharded_multires_mesh_tasks(mesh_path, num_lod=4))
-		tq.execute()
+		log.log("S3 Upload", f"full remote path: {mesh_path}", log_level=log.DEBUG.STATUS)
+		if execute:
+			tq = LocalTaskQueue(parallel=process_count // 4)
+			tq.insert(tc.create_meshing_tasks(mesh_path, mip=0))
+			tq.execute()
+			tq.insert(tc.create_unsharded_multires_mesh_tasks(mesh_path, num_lod=4))
+			tq.execute()
+		else:
+			log.log("S3 Upload", f"Would mesh {mesh_path}", log_level=log.DEBUG.INFO)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Stacked on #55. Completes the Phase 5 sweep.

### `print` -> `shared.log.log`

Remaining diagnostic prints are routed through `shared.log.log`:

- `transform/stitch.py` (also drops the commented-out `# print(f\"{offset}|...\")` debug line)
- `transform/mesh.py`
- `transform/channelize.py` (also drops the commented-out inline print)
- `transform/df_write_tiff.py` (the Dragonfly env-init banner)
- `transport/s3upload.py`
- `parsing/pull_config.py`
- `parsing/scanlog_fetch.py` (was already `click.echo`; logged uniformly now)
- `mem/clean.py` (keeps the existing `--apply` semantics)
- `hpc_work/timecheck.py`

### `--execute` / `--dry-run`

The remaining write-heavy commands gain a `--execute/--dry-run` switch, matching the trim / normalize / sinogram / uncompress / hdf-convert pattern from #54-#55:

- `transform stitch`, `transform channelize`, `transform df-write-tiff`
- `mesh build`
- `transport s3-upload`, `transport cv-fetch`
- `parse pull-config`, `parse scanlog-fetch`
- `mem from-file`, `mem from-range`

### `parse prune-empty`

`parsing/empty_dir_removal.py` is restructured from a hardcoded `/gpfs` script into a real click command that takes `ROOT` as an argument and a `--pattern` option (defaulting to `*history` to preserve the original behavior). It defaults to `--dry-run` because `rmdir` is destructive. Registered as `parse prune-empty`.

### Test updates

The two Phase 1 regression tests that call `df_write_tiff.callback` and `s3upload.callback` directly are updated to pass the new positional `execute` argument.

### Per Instruction

`hpc_work/codeclist.txt` and `parsing/meta_shift.py` stay untouched in this slice.

## Test plan

- [x] `flake8 --extend-ignore=C901` on the changed surfaces (only pre-existing E501/E226/F401 warnings remain)
- [x] `python scripts/check_python_tabs.py`
- [x] `pytest tests -q` (70 passed)
- [x] `mctutil --help` plus per-command `--help` on every touched subcommand, including new `parse prune-empty`
- [x] `parse prune-empty` smoke-tested end-to-end: default `--dry-run` listed empty subdir without touching it; `--execute` removed it