### PR TITLE
Phase 3 follow-up: split meta_shift into engine + chenglab adapter

### DIFF
--- a/chenglab/__init__.py
+++ b/chenglab/__init__.py
@@ -1,0 +1,9 @@
+"""Cheng-Lab specific adapters for mctutil generic tools.
+
+The contents of this package encode conventions (folder layouts, status enums,
+sbatch parameter formats, Google Sheets layouts) that are specific to the
+Cheng Lab's micro-CT pipeline. They are kept in-repo as the default schema
+for `mctutil parse meta-shift` but live behind the generic adapter seam in
+parsing/meta_shift.py so additional schemas can be added without touching the
+engine.
+"""

--- a/chenglab/meta_shift.py
+++ b/chenglab/meta_shift.py
@@ -1,0 +1,234 @@
+"""Cheng-Lab micro-CT schema for `mctutil parse meta-shift`.
+
+Holds the chenglab-specific bits that were previously inline in
+parsing/meta_shift.py: the STATUS enum, folder-name conventions, sbatch
+parameter extraction, Google Sheets row layout, and the *V.yaml discovery
+glob.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+from pathlib import Path
+from typing import Iterable
+
+from ruamel.yaml import YAML
+
+yaml = YAML()
+
+
+class STATUS(Enum):
+	EMPTY = auto()
+	FLATS_GENERATED_UC = auto()
+	FLATS_GENERATED = auto()
+	CENTERS_DUMPED_UC = auto()
+	CENTERS_DUMPED = auto()
+	INCOMPLETE_RECONSTRUCTION = auto()
+	RECONSTRUCTED_UC = auto()
+	RECONSTRUCTED = auto()
+
+	def __str__(self):
+		parts = [f'{part[:1].upper()}{part[1:].lower()}' for part in self.name.split("_")]
+		return " ".join(parts)
+
+	@staticmethod
+	def from_step(step, uc=True):
+		if step == "flats":
+			return STATUS.FLATS_GENERATED_UC if uc else STATUS.FLATS_GENERATED
+		if step == "centerfind":
+			return STATUS.CENTERS_DUMPED_UC if uc else STATUS.CENTERS_DUMPED
+		if step == "recon":
+			return STATUS.RECONSTRUCTED_UC if uc else STATUS.RECONSTRUCTED
+		return STATUS.EMPTY
+
+
+def get_outer_comment(folder):
+	components = folder.name.split("_")
+	outer_comment = []
+	energy = components[-1]
+	for part in components:
+		if len(part) == 6 and part[-3:].isnumeric() and not part[:3].isnumeric():
+			continue
+		if part != energy:
+			outer_comment.append(part)
+	return "_".join(outer_comment) if len(outer_comment) > 0 else ""
+
+
+def get_updated_config(old_config, empty_id):
+	with open(old_config) as conf:
+		conf_dict = yaml.load(conf)
+	if "comment" in conf_dict["storage"]:
+		base_comment = conf_dict["storage"].pop("comment").removesuffix("scans").removesuffix("_")
+		conf_dict["storage"]["has_scan"] = base_comment[-4:] == "scan"
+		conf_dict["storage"]["inner_comment"] = base_comment.removesuffix("scan").removesuffix("_")
+		conf_dict["storage"]["outer_comment"] = get_outer_comment(
+			Path(conf_dict["storage"].pop("override_input"))
+		)
+	scan_id = "_".join([
+		str(conf_dict["storage"]["outer_comment"]),
+		str(conf_dict["storage"]["inner_comment"]),
+	]).strip("_")
+	if scan_id == '':
+		scan_id = f"SS{empty_id}"
+		empty_id += 1
+	conf_dict["scan"]["id"] = scan_id
+	return conf_dict
+
+
+def get_paths(conf: dict, job_id):
+	steps = ["flats", "centerfind", "recon"]
+	old_paths = {}
+	new_paths = {}
+	data_path = Path(conf["storage"]["project"], conf["sample"]["id"], "data")
+
+	for step in steps:
+		if conf["storage"]["has_scan"]:
+			old_folder = (
+				f'{conf["scan"]["energy"]}kV_{conf["storage"]["inner_comment"]}_scan_{step}_p{job_id}'
+			).replace("__", "_")
+		else:
+			old_folder = f'{conf["scan"]["energy"]}kV_{conf["storage"]["inner_comment"]}_{step}_p{job_id}'
+		new_folder = f'{conf["scan"]["energy"]}kV_{conf["scan"]["id"]}_{step}_p{job_id}'
+		old_paths[step] = data_path.joinpath(old_folder)
+		new_paths[step] = data_path.joinpath(new_folder)
+
+	old_paths["script"] = data_path.joinpath(
+		"history",
+		f'{conf["scan"]["energy"]}kV_{conf["storage"]["inner_comment"]}',
+		job_id,
+	)
+	new_paths["script"] = data_path.joinpath(
+		"history",
+		f'{conf["scan"]["energy"]}kV_{conf["scan"]["id"]}',
+		job_id,
+	)
+	return old_paths, new_paths
+
+
+def get_run_params(batch_file: Path):
+	start_param = ""
+	stop_param = ""
+	base = ""
+	phase_alpha = None
+	with open(batch_file) as batch:
+		all_lines = batch.readlines()
+		run_command = all_lines[-1]
+		for line in all_lines:
+			if line[:5] == "start":
+				start_param = line.split(" ")[1]
+			if line[:4] == "stop":
+				stop_param = line.split(" ")[3]
+			if line[:11] == "phase_alpha":
+				phase_alpha = line.split("=")[1]
+			if line[:4] == "base":
+				base = line.split(" ")[2]
+
+	run_params = {
+		command_pair.split("=")[0][2:]: command_pair.split("=")[1]
+		for command_pair in run_command.split(".py")[1].strip("\n").strip().split(" ")
+		if "=" in command_pair
+	}
+
+	if "phase_tomo" not in run_params:
+		run_params["phase_tomo"] = "phase_alpha" not in run_params
+	if "stripe_removal" not in run_params:
+		run_params["stripe_removal"] = "VO (all)"
+	if "phase_alpha" not in run_params:
+		run_params["phase_alpha"] = 0.03
+	if phase_alpha is not None:
+		run_params["phase_alpha"] = str(run_params["phase_alpha"]).replace("$phase_alpha", phase_alpha)
+
+	run_params["slice_range"] = (
+		run_params["slice_range"]
+		.replace("$start", start_param)
+		.replace("$stop", stop_param)
+		.replace("base", base)
+	)
+	return run_params
+
+
+def build_sheet_row(conf_dict, run_params, drive, move_pairs, scan_num, status):
+	recon_line = []
+	remote_params = [
+		"machine_conf",
+		"sample_conf",
+		"old_file_naming",
+		"window_size",
+		"slice_range",
+		"recon_algorithm",
+		"job_id",
+		"phase_alpha",
+		"stripe_removal",
+		"phase_tomo",
+		"rot_center",
+		"tilt",
+	]
+	folder_fields = ["flats", "centerfind", "recon", "script"]
+	folders = [
+		str(drive.joinpath(conf_dict["storage"]["project"], conf_dict["sample"]["id"], "data"))
+	]
+
+	recon_line += [
+		'',
+		conf_dict["sample"]["id"],
+		conf_dict["storage"]["trip_dir"],
+		scan_num,
+		conf_dict["scan"]["id"],
+		conf_dict["storage"]["project"],
+		'',
+	]
+	recon_line += ['' if param not in run_params else str(run_params[param]) for param in remote_params]
+	recon_line += ['', str(status), '', '', '']
+
+	for field in folder_fields:
+		folders.append('' if field not in move_pairs else str(move_pairs[field]["to"].relative_to(folders[0])))
+
+	recon_line += folders
+	return recon_line
+
+
+class ChenglabMicroCTAdapter:
+	"""Default adapter for `mctutil parse meta-shift`.
+
+	Encodes Cheng-Lab micro-CT folder layout, status pipeline, sbatch parameter
+	extraction, and Google Sheets row format.
+	"""
+
+	name = "chenglab"
+	default_spreadsheet = "1RiCh3kjJhmUKZ5Y4UTwtKeiEag8jS_bU6jBeGJnru18"
+	default_sheet = "GPFS (DEN)"
+	steps = ("flats", "centerfind", "recon", "script")
+
+	def discover_sample_configs(self, drive: Path) -> list[Path]:
+		return list(drive.rglob("*V.yaml")) if drive.exists() else []
+
+	def load_sample_config(self, conf_path: Path, empty_id: int) -> dict:
+		return get_updated_config(conf_path, empty_id)
+
+	def compute_paths(self, conf: dict, job_id: str) -> tuple[dict, dict]:
+		return get_paths(conf, job_id)
+
+	def extract_run_params(self, sample_conf: Path) -> dict:
+		batch_list = [fname for fname in sample_conf.parent.iterdir() if fname.suffix == ".sbatch"]
+		if len(batch_list) > 0:
+			return get_run_params(batch_list[0])
+		with open(sample_conf.parent.joinpath("reconstruct_parameters.yaml")) as rp:
+			return yaml.load(rp)["reconstruct"]
+
+	def scan_num_from_config(self, sample_conf: Path) -> str:
+		return sample_conf.name.split("_")[0]
+
+	def status_for_step(self, step: str, uncorrected: bool = True):
+		return STATUS.from_step(step, uc=uncorrected)
+
+	def empty_status(self):
+		return STATUS.EMPTY
+
+	def step_order(self) -> Iterable[str]:
+		return self.steps
+
+	def build_sheet_row(self, conf_dict, run_params, drive, move_pairs, scan_num, status):
+		return build_sheet_row(conf_dict, run_params, drive, move_pairs, scan_num, status)
+
+	def transform_sample_config(self, conf_path: Path, empty_id: int) -> dict:
+		return get_updated_config(conf_path, empty_id)

--- a/parsing/meta_shift.py
+++ b/parsing/meta_shift.py
@@ -1,7 +1,18 @@
-from enum import Enum, auto
+"""Generic meta-shift engine.
+
+Drives a per-sample loop that delegates schema knowledge (folder conventions,
+status enum, sbatch parsing, sheet row layout) to a pluggable adapter. The
+default adapter is `chenglab.meta_shift:ChenglabMicroCTAdapter`; additional
+adapters can be registered by adding an entry to `ADAPTER_REGISTRY`.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
 from pathlib import Path
 from time import sleep
 import os
+import sys
 import traceback
 
 import click
@@ -12,141 +23,35 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
+# Needed to run script from subfolder
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared import log 	# noqa::E402
+
 yaml = YAML()
 
 
-class STATUS(Enum):
-	EMPTY = auto()
-	FLATS_GENERATED_UC = auto()
-	FLATS_GENERATED = auto()
-	CENTERS_DUMPED_UC = auto()
-	CENTERS_DUMPED = auto()
-	INCOMPLETE_RECONSTRUCTION = auto()
-	RECONSTRUCTED_UC = auto()
-	RECONSTRUCTED = auto()
-
-	def __str__(self):
-		parts = [f'{part[:1].upper()}{part[1:].lower()}' for part in self.name.split("_")]
-		return " ".join(parts)
-
-	@staticmethod
-	def from_step(step, uc=True):
-		if step == "flats":
-			return STATUS.FLATS_GENERATED_UC if uc else STATUS.FLATS_GENERATED
-		if step == "centerfind":
-			return STATUS.CENTERS_DUMPED_UC if uc else STATUS.CENTERS_DUMPED
-		if step == "recon":
-			return STATUS.RECONSTRUCTED_UC if uc else STATUS.RECONSTRUCTED
-		return STATUS.EMPTY
+# Schema registry. Keys are the values accepted for --schema; values are
+# "module:Class" import paths that resolve lazily so optional schema-specific
+# dependencies are not pulled in just to list --help.
+ADAPTER_REGISTRY = {
+	"chenglab": "chenglab.meta_shift:ChenglabMicroCTAdapter",
+}
 
 
-def get_outer_comment(folder):
-	components = folder.name.split("_")
-	outer_comment = []
-	energy = components[-1]
-	for part in components:
-		if len(part) == 6 and part[-3:].isnumeric() and not part[:3].isnumeric():
-			continue
-		if part != energy:
-			outer_comment.append(part)
-	return "_".join(outer_comment) if len(outer_comment) > 0 else ""
-
-
-def get_updated_config(old_config, empty_id):
-	with open(old_config) as conf:
-		conf_dict = yaml.load(conf)
-	if "comment" in conf_dict["storage"]:
-		base_comment = conf_dict["storage"].pop("comment").removesuffix("scans").removesuffix("_")
-		conf_dict["storage"]["has_scan"] = base_comment[-4:] == "scan"
-		conf_dict["storage"]["inner_comment"] = base_comment.removesuffix("scan").removesuffix("_")
-		conf_dict["storage"]["outer_comment"] = get_outer_comment(
-			Path(conf_dict["storage"].pop("override_input"))
+def load_adapter(name: str):
+	if name not in ADAPTER_REGISTRY:
+		raise click.BadParameter(
+			f"Unknown schema '{name}'. Known schemas: {', '.join(sorted(ADAPTER_REGISTRY))}.",
+			param_hint="--schema",
 		)
-	scan_id = "_".join([
-		str(conf_dict["storage"]["outer_comment"]),
-		str(conf_dict["storage"]["inner_comment"]),
-	]).strip("_")
-	if scan_id == '':
-		scan_id = f"SS{empty_id}"
-		empty_id += 1
-	conf_dict["scan"]["id"] = scan_id
-	return conf_dict
+	module_name, attr_name = ADAPTER_REGISTRY[name].split(":", 1)
+	module = import_module(module_name)
+	return getattr(module, attr_name)()
 
 
-def get_paths(conf: dict, job_id):
-	steps = ["flats", "centerfind", "recon"]
-	old_paths = {}
-	new_paths = {}
-	data_path = Path(conf["storage"]["project"], conf["sample"]["id"], "data")
-
-	for step in steps:
-		if conf["storage"]["has_scan"]:
-			old_folder = (
-				f'{conf["scan"]["energy"]}kV_{conf["storage"]["inner_comment"]}_scan_{step}_p{job_id}'
-			).replace("__", "_")
-		else:
-			old_folder = f'{conf["scan"]["energy"]}kV_{conf["storage"]["inner_comment"]}_{step}_p{job_id}'
-		new_folder = f'{conf["scan"]["energy"]}kV_{conf["scan"]["id"]}_{step}_p{job_id}'
-		old_paths[step] = data_path.joinpath(old_folder)
-		new_paths[step] = data_path.joinpath(new_folder)
-
-	old_paths["script"] = data_path.joinpath(
-		"history",
-		f'{conf["scan"]["energy"]}kV_{conf["storage"]["inner_comment"]}',
-		job_id,
-	)
-	new_paths["script"] = data_path.joinpath(
-		"history",
-		f'{conf["scan"]["energy"]}kV_{conf["scan"]["id"]}',
-		job_id,
-	)
-	return old_paths, new_paths
-
-
-def get_run_params(batch_file: Path):
-	start_param = ""
-	stop_param = ""
-	base = ""
-	phase_alpha = None
-	with open(batch_file) as batch:
-		all_lines = batch.readlines()
-		run_command = all_lines[-1]
-		for line in all_lines:
-			if line[:5] == "start":
-				start_param = line.split(" ")[1]
-			if line[:4] == "stop":
-				stop_param = line.split(" ")[3]
-			if line[:11] == "phase_alpha":
-				phase_alpha = line.split("=")[1]
-			if line[:4] == "base":
-				base = line.split(" ")[2]
-
-	run_params = {
-		command_pair.split("=")[0][2:]: command_pair.split("=")[1]
-		for command_pair in run_command.split(".py")[1].strip("\n").strip().split(" ")
-		if "=" in command_pair
-	}
-
-	if "phase_tomo" not in run_params:
-		run_params["phase_tomo"] = "phase_alpha" not in run_params
-	if "stripe_removal" not in run_params:
-		run_params["stripe_removal"] = "VO (all)"
-	if "phase_alpha" not in run_params:
-		run_params["phase_alpha"] = 0.03
-	if phase_alpha is not None:
-		run_params["phase_alpha"] = str(run_params["phase_alpha"]).replace("$phase_alpha", phase_alpha)
-
-	run_params["slice_range"] = (
-		run_params["slice_range"]
-		.replace("$start", start_param)
-		.replace("$stop", stop_param)
-		.replace("base", base)
-	)
-	return run_params
-
-
-def shift_old_new(drive, conf_dict, old_paths, new_paths, run_params, scan_num, execute=False):
-	status = STATUS.EMPTY
+def shift_old_new(adapter, drive, conf_dict, old_paths, new_paths, run_params, scan_num, execute=False):
+	status = adapter.empty_status()
 	keep_pairs = {}
 	move_pairs = {}
 	can_move = True
@@ -154,8 +59,9 @@ def shift_old_new(drive, conf_dict, old_paths, new_paths, run_params, scan_num, 
 	for step in old_paths:
 		old_target = drive.joinpath(old_paths[step])
 		new_target = drive.joinpath(new_paths[step])
-		if old_target.exists() and STATUS.from_step(step) is not STATUS.EMPTY:
-			status = STATUS.from_step(step)
+		step_status = adapter.status_for_step(step)
+		if old_target.exists() and step_status is not adapter.empty_status():
+			status = step_status
 
 		if old_paths[step] == new_paths[step] and old_target.exists():
 			keep_pairs[step] = {"from": old_target, "to": new_target}
@@ -221,6 +127,7 @@ def write_sheets_fields(creds, google_conf, gscopes, spreadsheet, sheet, values)
 
 
 def update_gsheet(
+		adapter,
 		creds,
 		google_conf,
 		gscopes,
@@ -233,43 +140,8 @@ def update_gsheet(
 		spreadsheet,
 		sheet,
 ):
-	recon_line = []
-	remote_params = [
-		"machine_conf",
-		"sample_conf",
-		"old_file_naming",
-		"window_size",
-		"slice_range",
-		"recon_algorithm",
-		"job_id",
-		"phase_alpha",
-		"stripe_removal",
-		"phase_tomo",
-		"rot_center",
-		"tilt",
-	]
-	folder_fields = ["flats", "centerfind", "recon", "script"]
-	folders = [
-		str(drive.joinpath(conf_dict["storage"]["project"], conf_dict["sample"]["id"], "data"))
-	]
-
-	recon_line += [
-		'',
-		conf_dict["sample"]["id"],
-		conf_dict["storage"]["trip_dir"],
-		scan_num,
-		conf_dict["scan"]["id"],
-		conf_dict["storage"]["project"],
-		'',
-	]
-	recon_line += ['' if param not in run_params else str(run_params[param]) for param in remote_params]
-	recon_line += ['', str(status), '', '', '']
-
-	for field in folder_fields:
-		folders.append('' if field not in move_pairs else str(move_pairs[field]["to"].relative_to(folders[0])))
-
-	recon_line += folders
-	return write_sheets_fields(creds, google_conf, gscopes, spreadsheet, sheet, recon_line)
+	row = adapter.build_sheet_row(conf_dict, run_params, drive, move_pairs, scan_num, status)
+	return write_sheets_fields(creds, google_conf, gscopes, spreadsheet, sheet, row)
 
 
 def parse_sample_list(sample_list_file):
@@ -280,13 +152,9 @@ def parse_sample_list(sample_list_file):
 	]
 
 
-def discover_sample_configs(drive):
-	return list(drive.rglob("*V.yaml")) if drive.exists() else []
-
-
-def write_updated_configs(config_dir, empty_id=0):
+def write_updated_configs(adapter, config_dir, empty_id=0):
 	for conf_path in [conf_path for conf_path in Path(config_dir).iterdir() if conf_path.suffix == ".yaml"]:
-		conf_dict = get_updated_config(conf_path, empty_id)
+		conf_dict = adapter.transform_sample_config(conf_path, empty_id)
 		new_conf_path = Path(conf_path.parent, "new", conf_path.name)
 		new_conf_path.parent.mkdir(parents=True, exist_ok=True)
 		with open(new_conf_path, "w") as out:
@@ -297,7 +165,7 @@ def cleanup_empty_history(drive):
 	for history in list(drive.rglob("*history")):
 		for inner_dir in history.iterdir():
 			if inner_dir.is_dir() and not bool(len(list(inner_dir.iterdir()))):
-				click.echo(f"Removing Empty {inner_dir}")
+				log.log("Meta Shift", f"Removing empty {inner_dir}", log_level=log.DEBUG.STATUS)
 				inner_dir.rmdir()
 
 
@@ -307,6 +175,7 @@ def load_machine_config(machine_conf):
 
 
 def run_meta_shift(
+		adapter,
 		sample_conf_list,
 		drive,
 		spreadsheet,
@@ -323,20 +192,16 @@ def run_meta_shift(
 	for sample_conf in sample_conf_list:
 		try:
 			job_id = sample_conf.parent.stem
-			conf_dict = get_updated_config(sample_conf, empty_id)
-			old_paths, new_paths = get_paths(conf_dict, job_id)
-			batch_list = [fname for fname in sample_conf.parent.iterdir() if fname.suffix == ".sbatch"]
-			if len(batch_list) > 0:
-				run_params = get_run_params(batch_list[0])
-			else:
-				with open(sample_conf.parent.joinpath("reconstruct_parameters.yaml")) as rp:
-					run_params = yaml.load(rp)["reconstruct"]
+			conf_dict = adapter.load_sample_config(sample_conf, empty_id)
+			old_paths, new_paths = adapter.compute_paths(conf_dict, job_id)
+			run_params = adapter.extract_run_params(sample_conf)
 
-			scan_num = sample_conf.name.split("_")[0]
+			scan_num = adapter.scan_num_from_config(sample_conf)
 			if "job_id" not in run_params:
 				run_params["job_id"] = job_id
 
 			status, written, move_pairs, keep_pairs = shift_old_new(
+				adapter,
 				drive,
 				conf_dict,
 				old_paths,
@@ -347,6 +212,7 @@ def run_meta_shift(
 			)
 			if written and update_sheet:
 				update_gsheet(
+					adapter,
 					creds,
 					google_conf,
 					gscopes,
@@ -360,12 +226,20 @@ def run_meta_shift(
 					sheet,
 				)
 		except IndexError as ex:
-			click.echo(f"{sample_conf}: {ex}: {traceback.format_exc()}")
+			log.log("Meta Shift", f"{sample_conf}: {ex}: {traceback.format_exc()}",
+					log_level=log.DEBUG.ERROR)
 		if sleep_seconds > 0:
 			sleep(sleep_seconds)
 
 
 @click.command()
+@click.option(
+	"--schema",
+	type=click.Choice(sorted(ADAPTER_REGISTRY), case_sensitive=False),
+	default=lambda: os.environ.get("MCTUTIL_META_SHIFT_SCHEMA", "chenglab"),
+	show_default="chenglab",
+	help="Adapter selecting per-lab folder conventions, status enum, sbatch format, and sheet layout.",
+)
 @click.option(
 	"--machine-conf",
 	type=click.Path(exists=True, path_type=Path),
@@ -401,16 +275,13 @@ def run_meta_shift(
 )
 @click.option(
 	"--spreadsheet",
-	default=lambda: os.environ.get(
-		"MCTUTIL_GSHEET_ID",
-		"1RiCh3kjJhmUKZ5Y4UTwtKeiEag8jS_bU6jBeGJnru18",
-	),
-	show_default=True,
+	default=lambda: os.environ.get("MCTUTIL_GSHEET_ID"),
+	help="Google Sheets spreadsheet ID. Defaults to the selected schema's default if set, otherwise required.",
 )
 @click.option(
 	"--sheet",
-	default=lambda: os.environ.get("MCTUTIL_GSHEET_SHEET", "GPFS (DEN)"),
-	show_default=True,
+	default=lambda: os.environ.get("MCTUTIL_GSHEET_SHEET"),
+	help="Google Sheets sheet/tab name. Defaults to the selected schema's default if set, otherwise required.",
 )
 @click.option(
 	"--write-configs",
@@ -419,6 +290,7 @@ def run_meta_shift(
 )
 @click.option(
 	"--cleanup-empty-history",
+	"cleanup_empty",
 	is_flag=True,
 	help="Remove empty history subdirectories after processing.",
 )
@@ -442,6 +314,7 @@ def run_meta_shift(
 )
 @click.option("--sleep-seconds", type=click.FLOAT, default=0.0, show_default=True)
 def meta_shift(
+		schema,
 		machine_conf,
 		config_dir,
 		sample_configs,
@@ -450,14 +323,27 @@ def meta_shift(
 		spreadsheet,
 		sheet,
 		write_configs,
-		cleanup_empty_history,
+		cleanup_empty,
 		discover,
 		update_sheet,
 		execute,
 		sleep_seconds,
 ):
+	adapter = load_adapter(schema)
+
+	if spreadsheet is None:
+		spreadsheet = getattr(adapter, "default_spreadsheet", None)
+	if sheet is None:
+		sheet = getattr(adapter, "default_sheet", None)
+
+	if update_sheet and (spreadsheet is None or sheet is None):
+		raise click.UsageError(
+			"--spreadsheet and --sheet are required when --update-sheet is on and the selected "
+			"schema has no defaults (set MCTUTIL_GSHEET_ID / MCTUTIL_GSHEET_SHEET or pass them explicitly)."
+		)
+
 	if write_configs:
-		write_updated_configs(config_dir)
+		write_updated_configs(adapter, config_dir)
 
 	mac = load_machine_config(machine_conf)
 	drive = Path(mac["storage"]["drive"])
@@ -467,11 +353,12 @@ def meta_shift(
 	elif sample_list_file is not None:
 		resolved_configs = parse_sample_list(sample_list_file)
 	elif discover:
-		resolved_configs = discover_sample_configs(drive)
+		resolved_configs = adapter.discover_sample_configs(drive)
 	else:
 		resolved_configs = []
 
 	run_meta_shift(
+		adapter,
 		resolved_configs,
 		drive,
 		spreadsheet,
@@ -482,7 +369,7 @@ def meta_shift(
 		update_sheet=update_sheet,
 	)
 
-	if cleanup_empty_history:
+	if cleanup_empty:
 		cleanup_empty_history(drive)
 
 

--- a/tests/test_meta_shift_adapter.py
+++ b/tests/test_meta_shift_adapter.py
@@ -1,0 +1,123 @@
+"""Regression tests for the meta_shift adapter seam.
+
+Exercises that the generic engine in parsing/meta_shift.py routes through the
+chenglab adapter for path computation, status mapping, discovery, and sheet
+row layout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+
+
+def _write_sample_conf(path: Path, energy: str = "35", inner: str = "left", project: str = "AAA590"):
+	path.write_text(
+		"storage:\n"
+		f"  project: {project}\n"
+		f"  inner_comment: {inner}\n"
+		"  outer_comment: ''\n"
+		"  has_scan: false\n"
+		"  trip_dir: trip-001\n"
+		"sample:\n"
+		"  id: SAMPLE_001\n"
+		"scan:\n"
+		f"  energy: {energy}\n"
+		"  id: SAMPLE_001_X\n"
+	)
+
+
+def test_load_adapter_returns_chenglab_by_default(load_module):
+	engine = load_module("parsing/meta_shift.py")
+	adapter = engine.load_adapter("chenglab")
+	assert type(adapter).__name__ == "ChenglabMicroCTAdapter"
+	assert adapter.default_spreadsheet
+	assert adapter.default_sheet
+
+
+def test_load_adapter_rejects_unknown_schema(load_module):
+	engine = load_module("parsing/meta_shift.py")
+	with pytest.raises(click.BadParameter):
+		engine.load_adapter("does-not-exist")
+
+
+def test_chenglab_adapter_computes_step_paths(load_module):
+	chenglab = load_module("chenglab/meta_shift.py")
+	adapter = chenglab.ChenglabMicroCTAdapter()
+	conf = {
+		"storage": {"project": "ProjA", "inner_comment": "left", "outer_comment": "", "has_scan": False},
+		"sample": {"id": "S001"},
+		"scan": {"energy": "35", "id": "S001_X"},
+	}
+	old, new = adapter.compute_paths(conf, "job42")
+	assert old["flats"] == Path("ProjA/S001/data/35kV_left_flats_pjob42")
+	assert new["flats"] == Path("ProjA/S001/data/35kV_S001_X_flats_pjob42")
+	assert old["script"].parts[-1] == "job42"
+	assert new["script"].parts[-2] == "35kV_S001_X"
+
+
+def test_chenglab_adapter_status_pipeline_orders_steps(load_module):
+	chenglab = load_module("chenglab/meta_shift.py")
+	adapter = chenglab.ChenglabMicroCTAdapter()
+	assert adapter.empty_status() is chenglab.STATUS.EMPTY
+	assert adapter.status_for_step("flats") is chenglab.STATUS.FLATS_GENERATED_UC
+	assert adapter.status_for_step("flats", uncorrected=False) is chenglab.STATUS.FLATS_GENERATED
+	assert adapter.status_for_step("recon") is chenglab.STATUS.RECONSTRUCTED_UC
+	assert adapter.status_for_step("unknown") is chenglab.STATUS.EMPTY
+
+
+def test_chenglab_adapter_discovers_v_yaml_only(load_module, tmp_path):
+	chenglab = load_module("chenglab/meta_shift.py")
+	adapter = chenglab.ChenglabMicroCTAdapter()
+	(tmp_path / "samples").mkdir()
+	(tmp_path / "samples" / "35V.yaml").write_text("placeholder")
+	(tmp_path / "samples" / "notes.yaml").write_text("placeholder")
+	(tmp_path / "samples" / "70V.yaml").write_text("placeholder")
+	found = adapter.discover_sample_configs(tmp_path)
+	names = sorted(p.name for p in found)
+	assert names == ["35V.yaml", "70V.yaml"]
+
+
+def test_chenglab_adapter_builds_sheet_row(load_module, tmp_path):
+	chenglab = load_module("chenglab/meta_shift.py")
+	adapter = chenglab.ChenglabMicroCTAdapter()
+	conf = {
+		"storage": {"project": "ProjA", "trip_dir": "trip-7"},
+		"sample": {"id": "S001"},
+		"scan": {"id": "S001_X"},
+	}
+	run_params = {"slice_range": "0-100", "phase_alpha": "0.03"}
+	move_pairs = {
+		"flats": {"to": tmp_path / "ProjA/S001/data/35kV_S001_X_flats_pjob42"},
+	}
+	row = adapter.build_sheet_row(conf, run_params, tmp_path, move_pairs, "scan-3", chenglab.STATUS.FLATS_GENERATED_UC)
+	# Layout sanity: scan_num, scan_id, project surface in fixed columns; status string is present.
+	assert "S001" in row
+	assert "trip-7" in row
+	assert "scan-3" in row
+	assert "S001_X" in row
+	assert "ProjA" in row
+	assert "Flats Generated Uc" in row
+
+
+def test_engine_shift_old_new_honors_dry_run_default(load_module, tmp_path):
+	engine = load_module("parsing/meta_shift.py")
+	chenglab = load_module("chenglab/meta_shift.py")
+	adapter = chenglab.ChenglabMicroCTAdapter()
+	drive = tmp_path
+	(drive / "ProjA/S001/data").mkdir(parents=True)
+	old_paths = {"flats": Path("ProjA/S001/data/old"), "script": Path("history/ProjA/S001/job")}
+	new_paths = {"flats": Path("ProjA/S001/data/new"), "script": Path("history/ProjA/S001/job")}
+	(drive / old_paths["flats"]).mkdir(parents=True)
+	(drive / old_paths["script"]).mkdir(parents=True)
+	conf_dict = {"sample": {"id": "S001"}, "scan": {"id": "S001_X"}}
+
+	status, can_move, move_pairs, keep_pairs = engine.shift_old_new(
+		adapter, drive, conf_dict, old_paths, new_paths, {}, "scan-1", execute=False
+	)
+	assert (drive / old_paths["flats"]).exists()
+	assert not (drive / new_paths["flats"]).exists()
+	assert can_move is True
+	assert "flats" in move_pairs


### PR DESCRIPTION
## Summary

Phase 3 collapse left `parsing/meta_shift.py` carrying all the Cheng-Lab specifics inline. This PR pulls them behind a generic adapter seam so a second schema can be added later without touching the engine.

### Engine vs adapter

`parsing/meta_shift.py` is now schema-agnostic. It drives the per-sample loop, handles Google Sheets auth and append plumbing, runs file renames under `--execute`, and walks `--cleanup-empty-history`. It knows about `dict` configs and `pathlib`, nothing else.

A new top-level `chenglab/` package holds `ChenglabMicroCTAdapter` and everything chenglab-specific that was inline before:

- `STATUS` enum (Flats / Centers / Recon pipeline)
- `get_outer_comment` 6-char-numeric naming heuristic
- `get_paths` folder layout (`{energy}kV_{...}_{step}_p{job_id}`)
- `get_run_params` sbatch parser (start / stop / phase_alpha / base + trailing tomopy command)
- 30-column `build_sheet_row` layout
- `*V.yaml` discovery glob
- Default spreadsheet ID and `\"GPFS (DEN)\"` sheet name as adapter attributes

### CLI surface

- `--schema chenglab` (default; env override `MCTUTIL_META_SHIFT_SCHEMA`).
- Adapter registry is a one-dict-entry registry in the engine; no plugin protocol, no setuptools entry points. Per discussion this is aspirational only.
- The previously-default chenglab spreadsheet ID and `\"GPFS (DEN)\"` sheet name are removed from the engine defaults; they live with the chenglab adapter as `default_spreadsheet` / `default_sheet`. When `--update-sheet` is on, the engine falls back to those defaults, then env vars, then errors if still unset.
- Today's chenglab invocation is wire-compatible: `mctutil parse meta-shift` with no flags resolves to the chenglab adapter and the same spreadsheet/sheet defaults as before.

### New tests

`tests/test_meta_shift_adapter.py`:

- Adapter registry lookup (success path + `click.BadParameter` on unknown schema)
- Chenglab path computation against a fixture conf dict
- STATUS pipeline ordering (incl. corrected vs uncorrected, unknown step -> EMPTY)
- `*V.yaml` discovery filter
- Sheet row layout sanity (key chenglab fields land in the row)
- Engine `shift_old_new` honors `execute=False`

## Test plan

- [x] `flake8 --extend-ignore=C901` on `parsing/meta_shift.py`, `chenglab/`, and the new test file (clean)
- [x] `python scripts/check_python_tabs.py`
- [x] `pytest tests -q` (77 passed, up from 70 — 7 new adapter regressions)
- [x] `mctutil parse meta-shift --help` shows the new `--schema` option and chenglab as the only registered choice