### PR TITLE
Phase 4 fix: ship top-level leaf packages so installed mctutil resolves

### DIFF
--- a/hpc_env/__init__.py
+++ b/hpc_env/__init__.py
@@ -1,0 +1,5 @@
+"""HPC environment probes (CUDA, etc.).
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/hpc_work/__init__.py
+++ b/hpc_work/__init__.py
@@ -1,0 +1,5 @@
+"""HPC scheduler-side helpers (time checks, etc.).
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/mem/__init__.py
+++ b/mem/__init__.py
@@ -1,0 +1,5 @@
+"""Shared-memory cleanup and node submission helpers.
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/ng/__init__.py
+++ b/ng/__init__.py
@@ -1,0 +1,5 @@
+"""Neuroglancer JSON / annotation tools.
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/parsing/__init__.py
+++ b/parsing/__init__.py
@@ -1,0 +1,5 @@
+"""Metadata, config, and scanlog parsing helpers.
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,13 @@ testpaths = ["tests"]
 where = ["."]
 include = [
   "mctutil*",
+  "chenglab*",
+  "hpc_env*",
+  "hpc_work*",
+  "mem*",
+  "ng*",
+  "parsing*",
+  "shared*",
+  "transform*",
+  "transport*",
 ]

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,0 +1,5 @@
+"""Shared helpers (logging, CLI types, shared-memory).
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/transform/__init__.py
+++ b/transform/__init__.py
@@ -1,0 +1,5 @@
+"""TIFF stack transforms and related local data reshaping helpers.
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""

--- a/transport/__init__.py
+++ b/transport/__init__.py
@@ -1,0 +1,5 @@
+"""Remote storage and data movement helpers.
+
+Marked as a real package so the unified CLI can lazy-import its leaves
+post-install.
+"""


### PR DESCRIPTION
## Summary

`pip install -e .` (or `pip install .`) was registering the `mctutil` console script but not actually shipping the leaf modules it imports — so running `mctutil ...` from any cwd outside the repo fails with `ModuleNotFoundError: No module named 'transform'` (or `ng`, `parsing`, ...). `python -m mctutil.cli` from inside the repo works because cwd is on `sys.path`, masking the issue.

Two compounding causes:

1. Phase 4's lazy CLI imports leaves by their **top-level module path** (e.g. `transform.uncompress:uncompress`, `ng.layer_copy:layer_copy`), not via the `mctutil` namespace.
2. `pyproject.toml` only listed `mctutil*` under `[tool.setuptools.packages.find].include`. The leaf directories were also **implicit namespace packages** (no `__init__.py`), which setuptools' `find:` directive skips by default.

### Fix

- Add a short docstring `__init__.py` to each top-level leaf (`hpc_env`, `hpc_work`, `mem`, `ng`, `parsing`, `shared`, `transform`, `transport`). `chenglab/__init__.py` already existed from #58.
- Extend `[tool.setuptools.packages.find].include` to cover the new packages.

No behavior change for in-repo invocations.

### Out of scope

The promised "move leaves under `mctutil/`" follow-up (REFACTOR_PLAN.md §3.3 / §7) that would remove the `sys.path.append(parents[1])` shim from every leaf is still outstanding. This PR is the minimum needed to unblock `pip install`-then-run.

## Test plan

- [x] `pip install -e .` in the mctutil-ci conda env
- [x] `mctutil --help` from `/tmp` (outside the repo) lists all groups
- [x] `mctutil transform decompress-tiff --help`, `mctutil parse meta-shift --help`, `mctutil ng point-shift --help` all resolve from `/tmp`
- [x] `flake8 --extend-ignore=C901` on all new `__init__.py` files
- [x] `python scripts/check_python_tabs.py`
- [x] `pytest tests -q` (77 passed)