### PR TITLE
cleanup: sweep os.path / os.walk callsites to pathlib

### DIFF
--- a/mctutil/hpc/timecheck.py
+++ b/mctutil/hpc/timecheck.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from os import walk
 from pathlib import Path
 
 import click
@@ -9,32 +8,34 @@ from mctutil.shared import log
 
 
 @click.command()
-@click.option("--scan_root", type=click.Path(), required=True,
+@click.option("--scan_root", type=click.Path(path_type=Path), required=True,
 				help="Root to search for projection start/stop from images.")
 def timecheck(scan_root):
 	scandatalist = []
-	for root, dirs, files in walk(scan_root):
-		if Path(root).name == 'projections':
-			base = Path(root).parent
-			if len(files) > 0:
-				files.sort()
-				try:
-					stop = int(Path(files[-1]).stem.split('_')[-1])
-					start = int(Path(files[0]).stem.split('_')[-1])
-					duration = stop - start
-					scan_duration = timedelta(milliseconds=duration / 1000000)
-					with Path(base, 'scanlog.txt').open('r') as handle:
-						timestring = handle.readline()[-27:-1]
-					scan_start = datetime.strptime(timestring, '%Y-%m-%d %H:%M:%S.%f')
-					projection_size = Path(root, files[-1]).stat().st_size / 1000000
-					scan_label = '_'.join(base.name.split('_')[3:-1])
-					scandatalist.append(
-						f"{scan_start},{scan_start + scan_duration},"
-						f"{base.parent.parent.name},{base.parent.name},"
-						f"{scan_label},{projection_size:.1f}MB"
-					)
-				except Exception as ex:
-					log.log("Time Check", f"{ex}", log_level=log.DEBUG.ERROR)
+	for projections in scan_root.rglob("projections"):
+		if not projections.is_dir():
+			continue
+		files = sorted(p for p in projections.iterdir() if p.is_file())
+		if not files:
+			continue
+		base = projections.parent
+		try:
+			stop = int(files[-1].stem.split('_')[-1])
+			start = int(files[0].stem.split('_')[-1])
+			duration = stop - start
+			scan_duration = timedelta(milliseconds=duration / 1000000)
+			with (base / 'scanlog.txt').open('r') as handle:
+				timestring = handle.readline()[-27:-1]
+			scan_start = datetime.strptime(timestring, '%Y-%m-%d %H:%M:%S.%f')
+			projection_size = files[-1].stat().st_size / 1000000
+			scan_label = '_'.join(base.name.split('_')[3:-1])
+			scandatalist.append(
+				f"{scan_start},{scan_start + scan_duration},"
+				f"{base.parent.parent.name},{base.parent.name},"
+				f"{scan_label},{projection_size:.1f}MB"
+			)
+		except Exception as ex:
+			log.log("Time Check", f"{ex}", log_level=log.DEBUG.ERROR)
 	scandatalist.sort()
 	for line in scandatalist:
 		log.log("Time Check", line, log_level=log.DEBUG.INFO)

--- a/mctutil/parse/find_err_general.py
+++ b/mctutil/parse/find_err_general.py
@@ -1,4 +1,3 @@
-from os import walk
 from sys import argv
 from pathlib import Path
 
@@ -11,14 +10,13 @@ job_set = set()
 no_error_set = set()
 
 with open(argv[2], "w") as output, open(argv[3], "w") as ne_output:
-	for root, dirs, files in walk(argv[1]):
-		for file in files:
-			if file[:3] == "err":
-				err_path = Path(root, file)
-				if not is_empty(err_path):
-					job_set.add(f'{err_path.parent}\n')
-				else:
-					no_error_set.add(f'{err_path.parent}\n')
+	for err_path in Path(argv[1]).rglob("err*"):
+		if not err_path.is_file():
+			continue
+		if not is_empty(err_path):
+			job_set.add(f'{err_path.parent}\n')
+		else:
+			no_error_set.add(f'{err_path.parent}\n')
 
 	no_error_set = no_error_set - job_set
 	output.writelines(job_set)

--- a/mctutil/transport/cv_import.py
+++ b/mctutil/transport/cv_import.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import os
 from multiprocessing import Pool
 from pathlib import Path
 
@@ -22,7 +21,7 @@ def fetch_slices(remote, use_https, region, bin_power, output_dir, execute=True)
 		return
 	vol = CloudVolume(remote, mip=bin_power, use_https=use_https, progress=True)
 	for i, slice_data in enumerate(vol[region], start=region[0].start):
-		tifffile.imwrite(os.path.join(output_dir, f"slice_{str(i).zfill(4)}.tif"), slice_data)
+		tifffile.imwrite(output_dir / f"slice_{str(i).zfill(4)}.tif", slice_data)
 
 
 def bin_slices(base_slice, bin_power, base_dim):

--- a/mctutil/transport/s3upload.py
+++ b/mctutil/transport/s3upload.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from taskqueue import LocalTaskQueue
 
@@ -49,17 +48,15 @@ def upload_file_to_s3(file_path, key, bucket_name, content_encoding, execute=Tru
 
 
 def upload_folder_to_s3_parallel(folder_path, target_folder, bucket_name, num_processes, execute=True):
+	folder_path = Path(folder_path)
 	with ProcessPoolExecutor(max_workers=num_processes) as executor:
-		for root, dirs, files in os.walk(str(folder_path)):
-			for dir_name in dirs:
-				dir_path = Path(root).joinpath(dir_name)
-				key = target_folder.joinpath(dir_path.relative_to(folder_path))
-				executor.submit(upload_file_to_s3, dir_path, key, bucket_name, None, execute)
-			for file_name in files:
-				file_path = Path(root).joinpath(file_name)
-				key = target_folder.joinpath(file_path.relative_to(folder_path))
-				content_encoding = 'gzip' if file_name != 'info' else None
-				executor.submit(upload_file_to_s3, file_path, key, bucket_name, content_encoding, execute)
+		for entry in folder_path.rglob("*"):
+			key = target_folder.joinpath(entry.relative_to(folder_path))
+			if entry.is_dir():
+				executor.submit(upload_file_to_s3, entry, key, bucket_name, None, execute)
+			else:
+				content_encoding = 'gzip' if entry.name != 'info' else None
+				executor.submit(upload_file_to_s3, entry, key, bucket_name, content_encoding, execute)
 
 
 @click.command()


### PR DESCRIPTION
## Summary

Finishes REFACTOR_PLAN.md §1.5 — \"Mixed \`os.path\` / \`pathlib\` use\" was flagged as still-open after Phase 3 deleted the worst offenders (\`quick_crop.py\`, \`upload.py\`). This sweeps the remaining four call-sites across the unified-CLI surface.

### Conversions

| File | Before | After |
|------|--------|-------|
| \`mctutil/transport/cv_import.py\` | \`tifffile.imwrite(os.path.join(output_dir, ...), data)\` | \`tifffile.imwrite(output_dir / ..., data)\` (caller already passes a Path) |
| \`mctutil/parse/find_err_general.py\` | \`for root, dirs, files in walk(argv[1]):\` then check \`file[:3] == \"err\"\` | \`for err_path in Path(argv[1]).rglob(\"err*\"):\` |
| \`mctutil/transport/s3upload.py\` | \`os.walk(str(folder_path))\` with per-dir / per-file branches | \`folder_path.rglob(\"*\")\` with an \`is_dir()\` / else-file branch |
| \`mctutil/hpc/timecheck.py\` | \`for root, dirs, files in walk(scan_root)\` then \`if Path(root).name == 'projections'\` | \`for projections in scan_root.rglob(\"projections\")\`; \`--scan_root\` option switches to \`click.Path(path_type=Path)\` |

### Items left alone

- \`os.environ\` in \`mctutil/parse/meta_shift.py\` and \`mctutil/transform/df_write_tiff.py\` — env-var access has no pathlib equivalent.
- \`from os import PathLike\` in \`mctutil/shared/io_helpers.py\`, \`mctutil/shared/mem.py\`, \`mctutil/transform/sinogram.py\`, \`mctutil/transform/normalize.py\`, \`mctutil/transform/transform.py\` — canonical use of the abstract type for path-like inputs.

## Test plan

- [x] \`flake8 mctutil scripts tests\` clean
- [x] \`python scripts/check_python_tabs.py\` clean
- [x] \`pytest tests -q\` -> 77 passed
- [x] \`mctutil --help\` plus \`transport cv-fetch --help\`, \`transport s3-upload --help\`, \`hpc time-check --help\` all resolve from outside the repo
- [x] End-to-end smoke test of \`hpc time-check\` against a fixture projections tree — confirms the rglob-based walk emits the expected line (3m20s duration matching the simulated start/stop timestamps)
- [x] End-to-end smoke test of \`find_err_general.py\` against a fixture with one non-empty and one empty err file — confirms the correct job-set / no-error-set partition