### PR TITLE
Port lftomo logger, rename log.log -> log.write, wire --log-level

### DIFF
--- a/mctutil/cli.py
+++ b/mctutil/cli.py
@@ -7,14 +7,42 @@ from mctutil.mem import main as mem_group
 from mctutil.mesh import main as mesh_group
 from mctutil.ng import main as ng_group
 from mctutil.parse import main as parse_group
+from mctutil.shared.log import log, LOG_MASK_QUIET, LOG_MASK_DEFAULT, LOG_MASK_VERBOSE, LOG_MASK_ALL
 from mctutil.sino import main as sino_group
 from mctutil.transform import main as transform_group
 from mctutil.transport import main as transport_group
 
 
+_LOG_LEVEL_MASKS = {
+	"quiet": LOG_MASK_QUIET,
+	"default": LOG_MASK_DEFAULT,
+	"verbose": LOG_MASK_VERBOSE,
+	"debug": LOG_MASK_ALL,
+}
+
+
 @click.group(help="Unified mctutil command surface.")
-def main():
+@click.option(
+	"--log-level",
+	type=click.Choice(list(_LOG_LEVEL_MASKS), case_sensitive=False),
+	default="default",
+	show_default=True,
+	help=(
+		"Verbosity for stdout. quiet=ERROR only; default adds STATUS/TIME/WARN; "
+		"verbose adds INFO; debug adds DEBUG."
+	),
+)
+@click.option("--quiet", "-q", "quiet_flag", is_flag=True,
+				help="Shorthand for --log-level quiet.")
+@click.option("--verbose", "-v", "verbose_flag", is_flag=True,
+				help="Shorthand for --log-level verbose.")
+def main(log_level, quiet_flag, verbose_flag):
 	"""Root command for the Phase 4 unified CLI."""
+	if quiet_flag:
+		log_level = "quiet"
+	elif verbose_flag:
+		log_level = "verbose"
+	log.set_threshold(_LOG_LEVEL_MASKS[log_level.lower()])
 
 
 main.add_command(transform_group, "transform")

--- a/mctutil/hpc/timecheck.py
+++ b/mctutil/hpc/timecheck.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -35,10 +35,10 @@ def timecheck(scan_root):
 				f"{scan_label},{projection_size:.1f}MB"
 			)
 		except Exception as ex:
-			log.log("Time Check", f"{ex}", log_level=log.DEBUG.ERROR)
+			log.write("Time Check", f"{ex}", log_level=LOG.ERROR)
 	scandatalist.sort()
 	for line in scandatalist:
-		log.log("Time Check", line, log_level=log.DEBUG.INFO)
+		log.write("Time Check", line, log_level=LOG.INFO)
 
 
 if __name__ == '__main__':

--- a/mctutil/mem/clean.py
+++ b/mctutil/mem/clean.py
@@ -8,7 +8,7 @@ import click
 import ipyslurm
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 # Names of shared memory to be script-specific (for now)
 shm = {
@@ -63,8 +63,8 @@ def mem_clean(shared_base, apply, apply_kmp):
 					clean_target = shared_memory.SharedMemory(name=mem_name)
 					clean_target.close()
 					clean_target.unlink()
-				log.log("Mem Clean", f"{host}:{mem_name}:{apply}",
-						log_level=log.DEBUG.STATUS if apply else log.DEBUG.INFO)
+				log.write("Mem Clean", f"{host}:{mem_name}:{apply}",
+						log_level=LOG.STATUS if apply else LOG.INFO)
 			elif mem_name[:len(other_shm)] == other_shm:
 				if apply_kmp:
 					try:
@@ -73,8 +73,8 @@ def mem_clean(shared_base, apply, apply_kmp):
 						clean_target.unlink()
 					except FileNotFoundError:
 						pass
-					log.log("Mem Clean", f"{host}:{mem_name}:{apply}",
-							log_level=log.DEBUG.STATUS if apply else log.DEBUG.INFO)
+					log.write("Mem Clean", f"{host}:{mem_name}:{apply}",
+							log_level=LOG.STATUS if apply else LOG.INFO)
 
 
 @click.group()
@@ -149,7 +149,7 @@ python -X pycache_prefix=~/.pycache ~/mem/clean.py {param_str} clean
 			'--partition', partition,
 			'--nodes', str(len(nodes))
 ])
-			log.log("Mem Clean", f"Job {partition}:{res}", log_level=log.DEBUG.STATUS)
+			log.write("Mem Clean", f"Job {partition}:{res}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/mem/from_file.py
+++ b/mctutil/mem/from_file.py
@@ -4,7 +4,7 @@ from subprocess import run
 import click
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 def collect_idle_nodes(node_file: Path):
@@ -31,9 +31,9 @@ def from_file(sbatch_script: Path, execute: bool, node_file: Path):
 	for node in collect_idle_nodes(node_file):
 		if execute:
 			run(["sbatch", "-w", node, str(sbatch_script)])
-			log.log("Mem From File", f"sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.STATUS)
+			log.write("Mem From File", f"sbatch -w {node} {sbatch_script}", log_level=LOG.STATUS)
 		else:
-			log.log("Mem From File", f"Would sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.INFO)
+			log.write("Mem From File", f"Would sbatch -w {node} {sbatch_script}", log_level=LOG.INFO)
 
 
 if __name__ == "__main__":

--- a/mctutil/mem/from_range.py
+++ b/mctutil/mem/from_range.py
@@ -3,7 +3,7 @@ from subprocess import run
 import click
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 def expand_node_range(prefix: str, start: int, stop: int):
@@ -21,9 +21,9 @@ def from_range(prefix: str, start: int, stop: int, sbatch_script: str, execute: 
 	for node in expand_node_range(prefix, start, stop):
 		if execute:
 			run(["sbatch", "-w", node, sbatch_script])
-			log.log("Mem From Range", f"sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.STATUS)
+			log.write("Mem From Range", f"sbatch -w {node} {sbatch_script}", log_level=LOG.STATUS)
 		else:
-			log.log("Mem From Range", f"Would sbatch -w {node} {sbatch_script}", log_level=log.DEBUG.INFO)
+			log.write("Mem From Range", f"Would sbatch -w {node} {sbatch_script}", log_level=LOG.INFO)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/change_color.py
+++ b/mctutil/ng/change_color.py
@@ -5,7 +5,7 @@ import re
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.cli import DelimitedRecord
 
 
@@ -35,14 +35,14 @@ def change_color(json_file: Path, json_result: Path, annotation: str, segment_co
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Change Color", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Change Color", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	layer_names = [layer["name"] for layer in json_data["layers"]]
 	if annotation not in layer_names:
-		log.log("Change Color", f"Annotation {annotation} not found in JSON.", log_level=log.DEBUG.ERROR)
+		log.write("Change Color", f"Annotation {annotation} not found in JSON.", log_level=LOG.ERROR)
 		exit(1)
 	elif "segmentColors" not in json_data["layers"][layer_names.index(annotation)]:
-		log.log("Change Color", f"No segmentation colors in layer {annotation}", log_level=log.DEBUG.ERROR)
+		log.write("Change Color", f"No segmentation colors in layer {annotation}", log_level=LOG.ERROR)
 		exit(1)
 	else:
 		color_layer = json_data["layers"][layer_names.index(annotation)]["segmentColors"]
@@ -50,15 +50,15 @@ def change_color(json_file: Path, json_result: Path, annotation: str, segment_co
 			if str(color_pair.segment) in color_layer:
 				color_layer[str(color_pair.segment)] = color_pair.hval
 			else:
-				log.log("Change Color",
+				log.write("Change Color",
 						f"Segmentation ID {color_pair.segment} not found in layer {annotation}.",
-						log_level=log.DEBUG.WARN)
+						log_level=LOG.WARN)
 		json_data["layers"][layer_names.index(annotation)]["segmentColors"] = color_layer
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Change Color", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Change Color", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/layer_copy.py
+++ b/mctutil/ng/layer_copy.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -25,7 +25,7 @@ def layer_copy(json_file: Path, json_result: Path, json_target: Path, source_ann
 		json_source = json.load(json_handle)
 	with open(json_target) as json_handle:
 		json_target = json.load(json_handle)
-	log.log("Layer Copy", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Layer Copy", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	existing_annotations = [layer["name"] for layer in json_source["layers"]]
 	if len(source_annotations) > 0:
@@ -36,15 +36,15 @@ def layer_copy(json_file: Path, json_result: Path, json_target: Path, source_ann
 	annotations = [layer for layer in json_source["layers"] if
 					((layer["name"] in source_annotations) or (len(source_annotations) == 0))]
 
-	log.log("Layer Copy", f"{len(annotations)} found to copy", log_level=log.DEBUG.STATUS)
+	log.write("Layer Copy", f"{len(annotations)} found to copy", log_level=LOG.STATUS)
 
 	if len(source_annotations) > len(annotations):
 		missing_annotations = [layer_name for layer_name in source_annotations if layer_name not in existing_annotations]
-		log.log("Layer Copy", f"Annotations missing: {missing_annotations}", log_level=log.DEBUG.ERROR)
+		log.write("Layer Copy", f"Annotations missing: {missing_annotations}", log_level=LOG.ERROR)
 		return -1
 
 	if len(duplicate_layers) > 0:
-		log.log("Layer Copy", f"Some layers already exist in target: {duplicate_layers}", log_level=log.DEBUG.ERROR)
+		log.write("Layer Copy", f"Some layers already exist in target: {duplicate_layers}", log_level=LOG.ERROR)
 		return -1
 
 	json_target["layers"].extend(annotations)
@@ -52,7 +52,7 @@ def layer_copy(json_file: Path, json_result: Path, json_target: Path, source_ann
 	with open(json_result, "w") as handle:
 		json.dump(json_target, handle)
 
-	log.log("Layer Copy", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Layer Copy", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/layer_extract.py
+++ b/mctutil/ng/layer_extract.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -21,15 +21,15 @@ def layer_extract(json_file: Path, json_result: Path, layers: str):
 		"""
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
-	log.log("Layer Extract", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Layer Extract", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	source_layers = {layer["name"]: layer for layer in json_data["layers"]}
 	copy_layers = []
 	for layer in layers:
 		if layer not in source_layers:
-			log.log("Layer Extract", f"{layer} not found in source.", log_level=log.DEBUG.WARN)
+			log.write("Layer Extract", f"{layer} not found in source.", log_level=LOG.WARN)
 		else:
-			log.log("Layer Extract", f"{layer} retained.", log_level=log.DEBUG.STATUS)
+			log.write("Layer Extract", f"{layer} retained.", log_level=LOG.STATUS)
 			copy_layers.append(source_layers[layer])
 
 	json_data["layers"] = copy_layers
@@ -37,7 +37,7 @@ def layer_extract(json_file: Path, json_result: Path, layers: str):
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Layer Extract", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Layer Extract", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/layer_tag.py
+++ b/mctutil/ng/layer_tag.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 import numpy as np
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.cli import DelimitedRecord
 
 
@@ -43,7 +43,7 @@ TAGGEDLAYER = DelimitedRecord(
 def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: TaggedLayer):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
-	log.log("Layer Tag", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Layer Tag", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	preset_intensities = [layer.intensity for layer in tagged_layer]
 	intensity_step = np.iinfo(np.uint16).max // (len(tagged_layer) + 2)
@@ -52,7 +52,7 @@ def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: 
 	source_layers = {layer["name"]: layer for layer in json_data["layers"]}
 	for t_layer in tagged_layer:
 		if t_layer.name not in source_layers:
-			log.log("Layer Tag", f"{t_layer} not found in source.", log_level=log.DEBUG.WARN)
+			log.write("Layer Tag", f"{t_layer} not found in source.", log_level=LOG.WARN)
 		else:
 			if t_layer.intensity == -1:
 				t_layer = replace(t_layer, intensity=next(intensity_gen))
@@ -64,14 +64,14 @@ def layer_tag(json_file: Path, json_result: Path, segment_radius, tagged_layer: 
 
 			source_layers[t_layer.name]["name"] = str(t_layer)
 
-			log.log("Layer Tag", f"{t_layer.name} updated: {t_layer}.", log_level=log.DEBUG.STATUS)
+			log.write("Layer Tag", f"{t_layer.name} updated: {t_layer}.", log_level=LOG.STATUS)
 
 	json_data["layers"] = list(source_layers.values())
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Layer Tag", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Layer Tag", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/layer_urlshift.py
+++ b/mctutil/ng/layer_urlshift.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 def upd_layer(name, source, shifted_layers):
@@ -39,7 +39,7 @@ def layer_urlshift(json_file: Path, json_result: Path):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Layer URLShift", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Layer URLShift", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	shifted_layers = {layer["name"]: layer for layer in json_data["layers"]}
 	for name, layer in shifted_layers.items():
@@ -51,7 +51,7 @@ def layer_urlshift(json_file: Path, json_result: Path):
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Layer URLShift", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Layer URLShift", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/point_add.py
+++ b/mctutil/ng/point_add.py
@@ -6,7 +6,7 @@ import uuid
 import click
 import numpy as np
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -28,7 +28,7 @@ def point_add(json_file: Path, json_result: Path, base_layer: str, points: Path,
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Point Add", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Point Add", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	for layer in json_data["layers"]:
 		if layer["name"] == base_layer:
@@ -56,23 +56,23 @@ def point_add(json_file: Path, json_result: Path, base_layer: str, points: Path,
 			point_reader = csv.reader(csvfile)
 			point_array = np.array([row for row in point_reader])
 	else:
-		log.log("Point Add", "Points must be in .npy or .csv format.", log_level=log.DEBUG.ERROR)
+		log.write("Point Add", "Points must be in .npy or .csv format.", log_level=LOG.ERROR)
 		return
 
 	if len(point_array.shape) != 2 or point_array.shape[-1] != 3:
-		log.log("Point Add", "Points must be an array of 3D XYZ points.", log_level=log.DEBUG.ERROR)
+		log.write("Point Add", "Points must be an array of 3D XYZ points.", log_level=LOG.ERROR)
 		return
 
 	uuids = [uuid.uuid1() for x in range(len(point_array))]
 	new_layer["annotations"] = [{"type": "point", "id": str(idval), "point": list(point)}
 								for point, idval in zip(point_array, uuids)]
 	json_data["layers"].append(new_layer)
-	log.log("Point Add", "Annotation added", log_level=log.DEBUG.STATUS)
+	log.write("Point Add", "Annotation added", log_level=LOG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Point Add", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Point Add", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/point_merge.py
+++ b/mctutil/ng/point_merge.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.cli import DelimitedRecord
 
 
@@ -36,13 +36,13 @@ def point_merge(json_file: Path, json_result: Path, target_name: str, source_ann
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Point Merge", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Point Merge", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	annotation_names = [layer["name"] for layer in json_data["layers"]]
 
 	for pair in source_annotations:
 		if pair.name not in annotation_names:
-			log.log("Point Merge", f"Annotation {pair.name} missing.", log_level=log.DEBUG.ERROR)
+			log.write("Point Merge", f"Annotation {pair.name} missing.", log_level=LOG.ERROR)
 			return
 
 	new_annotation_layer = {
@@ -54,21 +54,21 @@ def point_merge(json_file: Path, json_result: Path, target_name: str, source_ann
 		"name": target_name,
 	}
 
-	log.log("Point Merge", "Base annotation created", log_level=log.DEBUG.STATUS)
+	log.write("Point Merge", "Base annotation created", log_level=LOG.STATUS)
 
 	for pair in source_annotations:
 		base_annotations = json_data["layers"][annotation_names.index(pair.name)]["annotations"]
 		in_order = base_annotations if pair.direction else list(reversed(base_annotations))
 		new_annotation_layer["annotations"] += in_order
 
-	log.log("Point Merge", "Merged annotation created", log_level=log.DEBUG.STATUS)
+	log.write("Point Merge", "Merged annotation created", log_level=LOG.STATUS)
 
 	json_data["layers"].append(new_annotation_layer)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Point Merge", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Point Merge", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/point_shift.py
+++ b/mctutil/ng/point_shift.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 import numpy as np
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.cli import DelimitedRecord
 
 Coord = namedtuple("Coord", ["x", "y", "z"])
@@ -25,7 +25,7 @@ def point_shift(json_file: Path, json_result: Path, shift_dimensions: Coord):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Point Shift", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Point Shift", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	for layer in json_data["layers"]:
 		if layer["type"] == "annotation":
@@ -33,12 +33,12 @@ def point_shift(json_file: Path, json_result: Path, shift_dimensions: Coord):
 				if annotation["type"] == "point":
 					annotation["point"] = list(np.add(annotation["point"], shift_dimensions))
 
-	log.log("Point Shift", "Annotations updated", log_level=log.DEBUG.STATUS)
+	log.write("Point Shift", "Annotations updated", log_level=LOG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Point Shift", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Point Shift", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/point_sort.py
+++ b/mctutil/ng/point_sort.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.cli import DelimitedRecord
 
 
@@ -35,25 +35,25 @@ def point_sort(json_file: Path, json_result: Path, axis: int, source_annotations
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Point Sort", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Point Sort", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	annotation_names = [layer["name"] for layer in json_data["layers"]]
 
 	for pair in source_annotations:
 		if pair.name not in annotation_names:
-			log.log("Point Sort", f"Annotation {pair.name} missing.", log_level=log.DEBUG.WARN)
+			log.write("Point Sort", f"Annotation {pair.name} missing.", log_level=LOG.WARN)
 		else:
 			base_annotations = json_data["layers"][annotation_names.index(pair.name)]["annotations"]
 			sorted_annotations = sorted(base_annotations, key=lambda x: x['point'][axis])
 			final_annotations = sorted_annotations if pair.direction else reversed(sorted_annotations)
 			json_data["layers"][annotation_names.index(pair.name)]["annotations"] = list(final_annotations)
 
-	log.log("Point Sort", "Annotations updated", log_level=log.DEBUG.STATUS)
+	log.write("Point Sort", "Annotations updated", log_level=LOG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Point Sort", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Point Sort", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/position_copy.py
+++ b/mctutil/ng/position_copy.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -24,18 +24,18 @@ def position_copy(json_file, json_result, json_target):
 	with open(json_target) as json_handle:
 		json_upd = json.load(json_handle)
 
-	log.log("Position Copy", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Position Copy", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	for field in ["position", "crossSectionOrientation", "crossSectionScale",
 					"projectionOrientation", "projectionScale", "layout", "layerListPanel"]:
 		json_upd[field] = json_data[field]
 
-	log.log("Position Copy", "Orientation updated", log_level=log.DEBUG.STATUS)
+	log.write("Position Copy", "Orientation updated", log_level=LOG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_upd, handle)
 
-	log.log("Position Copy", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Position Copy", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/ng/shift_angle.py
+++ b/mctutil/ng/shift_angle.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -23,7 +23,7 @@ def shift_angle(json_file, json_result, make_ortho):
 	with open(json_file) as json_handle:
 		json_data = json.load(json_handle)
 
-	log.log("Shift Angle", f"Loaded {json_file}", log_level=log.DEBUG.STATUS)
+	log.write("Shift Angle", f"Loaded {json_file}", log_level=LOG.STATUS)
 
 	json_data["projectionOrientation"] = [
 		0.3462526500225067,
@@ -32,7 +32,7 @@ def shift_angle(json_file, json_result, make_ortho):
 		0.8535001277923584
 	]
 
-	log.log("Shift Angle", "Orientation updated", log_level=log.DEBUG.STATUS)
+	log.write("Shift Angle", "Orientation updated", log_level=LOG.STATUS)
 
 	if make_ortho:
 		if isinstance(json_data["layout"], str):
@@ -42,12 +42,12 @@ def shift_angle(json_file, json_result, make_ortho):
 			}
 		else:
 			json_data["layout"]["orthographicProjection"] = True
-		log.log("Shift Angle", "Made orthographic, if not already.", log_level=log.DEBUG.STATUS)
+		log.write("Shift Angle", "Made orthographic, if not already.", log_level=LOG.STATUS)
 
 	with open(json_result, "w") as handle:
 		json.dump(json_data, handle)
 
-	log.log("Shift Angle", f"Wrote {json_result}", log_level=log.DEBUG.STATUS)
+	log.write("Shift Angle", f"Wrote {json_result}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/parse/empty_dir_removal.py
+++ b/mctutil/parse/empty_dir_removal.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import click
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -21,10 +21,10 @@ def prune_empty(pattern: str, execute: bool, root: Path):
 		for inner_dir in outer.iterdir():
 			if inner_dir.is_dir() and not any(inner_dir.iterdir()):
 				if execute:
-					log.log("Prune Empty", f"Removing empty {inner_dir}", log_level=log.DEBUG.STATUS)
+					log.write("Prune Empty", f"Removing empty {inner_dir}", log_level=LOG.STATUS)
 					inner_dir.rmdir()
 				else:
-					log.log("Prune Empty", f"Would remove empty {inner_dir}", log_level=log.DEBUG.INFO)
+					log.write("Prune Empty", f"Would remove empty {inner_dir}", log_level=LOG.INFO)
 
 
 if __name__ == "__main__":

--- a/mctutil/parse/meta_shift.py
+++ b/mctutil/parse/meta_shift.py
@@ -23,7 +23,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 yaml = YAML()
 
@@ -162,7 +162,7 @@ def cleanup_empty_history(drive):
 	for history in list(drive.rglob("*history")):
 		for inner_dir in history.iterdir():
 			if inner_dir.is_dir() and not bool(len(list(inner_dir.iterdir()))):
-				log.log("Meta Shift", f"Removing empty {inner_dir}", log_level=log.DEBUG.STATUS)
+				log.write("Meta Shift", f"Removing empty {inner_dir}", log_level=LOG.STATUS)
 				inner_dir.rmdir()
 
 
@@ -223,8 +223,8 @@ def run_meta_shift(
 					sheet,
 				)
 		except IndexError as ex:
-			log.log("Meta Shift", f"{sample_conf}: {ex}: {traceback.format_exc()}",
-					log_level=log.DEBUG.ERROR)
+			log.write("Meta Shift", f"{sample_conf}: {ex}: {traceback.format_exc()}",
+					log_level=LOG.ERROR)
 		if sleep_seconds > 0:
 			sleep(sleep_seconds)
 

--- a/mctutil/parse/pull_config.py
+++ b/mctutil/parse/pull_config.py
@@ -4,7 +4,7 @@ from shutil import copy
 import click
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -17,14 +17,14 @@ def get_conf(source, target, execute):
 	if execute:
 		Path(target).mkdir(exist_ok=True, parents=True)
 	else:
-		log.log("Pull Config", f"Would create {target}", log_level=log.DEBUG.INFO)
+		log.write("Pull Config", f"Would create {target}", log_level=LOG.INFO)
 	for conf in source_conf_set:
 		dest = Path(target, f"{conf.parent.name}_{conf.name}")
 		if execute:
-			log.log("Pull Config", f"{conf.parent.name}_{conf.name}", log_level=log.DEBUG.STATUS)
+			log.write("Pull Config", f"{conf.parent.name}_{conf.name}", log_level=LOG.STATUS)
 			copy(conf, dest)
 		else:
-			log.log("Pull Config", f"Would copy {conf} -> {dest}", log_level=log.DEBUG.INFO)
+			log.write("Pull Config", f"Would copy {conf} -> {dest}", log_level=LOG.INFO)
 
 
 if __name__ == "__main__":

--- a/mctutil/parse/scanlog_fetch.py
+++ b/mctutil/parse/scanlog_fetch.py
@@ -4,7 +4,7 @@ from shutil import copy
 import click
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -15,7 +15,7 @@ def scanlog_fetch(execute, root_dir):
 	if execute:
 		Path("logs").mkdir(exist_ok=True)
 	else:
-		log.log("Scanlog Fetch", "Would create logs/", log_level=log.DEBUG.INFO)
+		log.write("Scanlog Fetch", "Would create logs/", log_level=LOG.INFO)
 	for dir_name in root_dir:
 		for fullpath in Path(dir_name).rglob("scanlog.txt"):
 			software_trigger_scans = ["_post", "_pre", "_uncrop", "_crop", "_focus", "_step"]
@@ -24,12 +24,12 @@ def scanlog_fetch(execute, root_dir):
 					target = Path("logs", f"{fullpath.parent.name}_scanlog.txt")
 					if execute:
 						copy(fullpath, target)
-						log.log("Scanlog Fetch", f"{fullpath.parent.name}:{fullpath.stat().st_size}",
-								log_level=log.DEBUG.STATUS)
+						log.write("Scanlog Fetch", f"{fullpath.parent.name}:{fullpath.stat().st_size}",
+								log_level=LOG.STATUS)
 					else:
-						log.log("Scanlog Fetch",
+						log.write("Scanlog Fetch",
 								f"Would copy {fullpath} -> {target} (size {fullpath.stat().st_size})",
-								log_level=log.DEBUG.INFO)
+								log_level=LOG.INFO)
 
 
 if __name__ == "__main__":

--- a/mctutil/shared/io_helpers.py
+++ b/mctutil/shared/io_helpers.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from psutil import cpu_count
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.mem import SharedNP
 
 FlatPair = namedtuple("FlatPair", ["Index", "Offset"])
@@ -79,14 +79,14 @@ def distribute_read(target_mem: SharedNP, pj: Mapping, window, int_window,
 		return [{"source": pj["offset"] + window.start * h_step, "target": int(base_offset + i * proj_block_size)}]
 
 	if sino_order:
-		log.log("Files Into Memory", f"Writing (in {target_mem.name} | {target_mem.shape}) {base_offset}"
-			+ f" to {base_offset + len(int_window) * sino_block_size}", log_level=log.DEBUG.INFO)
+		log.write("Files Into Memory", f"Writing (in {target_mem.name} | {target_mem.shape}) {base_offset}"
+			+ f" to {base_offset + len(int_window) * sino_block_size}", log_level=LOG.INFO)
 		pairs_func = generate_offset_pairs_sino
 		size = h_step
 	else:
-		log.log("Files Into Memory", f"Writing (in {target_mem.name} | {target_mem.shape}) {base_offset}"
+		log.write("Files Into Memory", f"Writing (in {target_mem.name} | {target_mem.shape}) {base_offset}"
 			+ f" to {base_offset + len(int_window) * proj_block_size} out of {target_mem[int_window].buffer_address}",
-			log_level=log.DEBUG.INFO)
+			log_level=LOG.INFO)
 		pairs_func = generate_offset_pairs_proj
 		size = proj_block_size
 

--- a/mctutil/shared/log.py
+++ b/mctutil/shared/log.py
@@ -1,94 +1,210 @@
+"""Bitmask-filtered structured logger for mctutil.
+
+Ported from den-sq/lftomo's `lftomo/util/log.py` to align with the authoring
+conventions of the lab's other CLI tool, with three real bug-fixes vs. that
+source: the default file-log mask uses bitwise `|` (not `or`) so it actually
+combines the LOG flags it intends to; the IntFlag's redundant `__init__` is
+dropped (colors live in a property dict); and the default file-log path is
+allocated lazily via `set_log_file()` instead of being constructed at module
+import time relative to whatever cwd Python started in.
+
+Adds two surface tweaks over lftomo: `progress()` (mctutil's
+`click.progressbar` wrapper, was `log_progress` pre-rename) and `start()`
+(convenience for header + Script Start line, matches the pre-rename ergonomic).
+Public `set_screen()` / `set_threshold()` setters let the top-level `mctutil`
+CLI group wire `--log-level` / `--quiet` / `--verbose` without monkey-patching.
+
+Module-level singleton: `log = Logger()`. Idiomatic import shape is
+`from mctutil.shared.log import log, LOG`.
+"""
+
 from datetime import datetime
-from enum import Enum
-from sys import stdout
+from enum import IntFlag
+from functools import reduce
+from operator import ior
+from pathlib import Path
+from sys import stdout, exc_info
 from typing import TextIO
 
 import click
 import psutil
 
-script_start = datetime.now()
 
-__attached_funcs = []
-
-
-class DEBUG(Enum):
-	SILENT = ("SILENT", 0, "black")
-	ERROR = ("ERROR", 1, "red")
-	STATUS = ("STATUS", 2, "green")
-	TIME = ("TIME", 3, "cyan")
-	WARN = ("WARN", 4, "yellow")
-	INFO = ("INFO", 5, "white")
-
-	def __str__(self):
-		return str(self.value[0])
-
-	def __le__(self, other):
-		return self.value[1] <= other.value[1]
+class LOG(IntFlag):
+	SILENT = 0
+	ERROR = 1
+	STATUS = 2
+	TIME = 4
+	WARN = 8
+	INFO = 16
+	DEBUG = 32
 
 	@property
 	def color(self):
-		return self.value[2]
+		return {
+			LOG.SILENT: "black",
+			LOG.ERROR: "red",
+			LOG.STATUS: "green",
+			LOG.TIME: "cyan",
+			LOG.WARN: "yellow",
+			LOG.INFO: "white",
+			LOG.DEBUG: "magenta",
+		}[self]
 
 
-def __log_message(step: str, statement: str = '', log_level: DEBUG = DEBUG.TIME):
-	styled_type = click.style(f'{log_level.name:6}', log_level.color)
-	message = (f'{styled_type}'
-			f'|{step[:20]:20}'
-			f'|{str(datetime.now() - script_start).zfill(15)}'
-			f'|{psutil.Process().memory_info().vms // 1024 ** 2:09.2f}MB'
-			f'|{psutil.virtual_memory().available // 1024 ** 2:09.2f}MB'
-			f'|"{statement}"')
-	return message
+# Convenience masks for the top-level CLI plumbing. Each is the set of
+# levels that get routed to stdout at that verbosity.
+LOG_MASK_QUIET = LOG.ERROR
+LOG_MASK_DEFAULT = LOG.ERROR | LOG.STATUS | LOG.TIME | LOG.WARN
+LOG_MASK_VERBOSE = LOG.ERROR | LOG.STATUS | LOG.TIME | LOG.WARN | LOG.INFO
+LOG_MASK_ALL = LOG.ERROR | LOG.STATUS | LOG.TIME | LOG.WARN | LOG.INFO | LOG.DEBUG
 
 
-def start():
-	click.echo(f'{"TYPE":6}|{"STEP":20}|   TIMESTAMP   | MEM USAGE | MEM FREE  | STATEMENT ')
-	log("Script Start", script_start)
+class Logger:
+	"""Bitmask-filtered structured logger.
+
+	Each line has shape `TYPE|STEP|TIMESTAMP|MEM_USE|MEM_FREE|STATEMENT` and is
+	dispatched via per-destination masks: `__log_screen` (a `{stdout, stderr}`
+	dict, each value a LOG mask) and `__logs` (a `{name: (Path, LOG)}` dict for
+	named file destinations). A level emits to a destination iff its bit is set
+	in that destination's mask.
+	"""
+
+	def __init__(self, log_screen=None, log_files=None):
+		self.script_start = datetime.now()
+		self.__attached_funcs = []
+		self.__log_screen = log_screen if log_screen is not None else {
+			"stdout": LOG_MASK_DEFAULT,
+			"stderr": LOG.ERROR,
+		}
+		# Bug-fix vs. lftomo: default to no file logs; opt in via
+		# ``set_log_file()`` so we don't allocate a path at import time.
+		self.__logs = log_files if log_files is not None else {}
+		self.__pid = psutil.Process().pid
+
+	def set_screen(self, stdout_mask=None, stderr_mask=None):
+		"""Replace per-stream LOG masks. ``None`` leaves a stream unchanged."""
+		if stdout_mask is not None:
+			self.__log_screen["stdout"] = stdout_mask
+		if stderr_mask is not None:
+			self.__log_screen["stderr"] = stderr_mask
+
+	def set_threshold(self, mask):
+		"""Convenience: set stdout mask to ``mask`` and stderr mask to ``LOG.ERROR``."""
+		self.set_screen(stdout_mask=mask, stderr_mask=LOG.ERROR)
+
+	def set_log_file(self, name, path, mask=None):
+		"""Add or replace a named file destination.
+
+		Default mask is everything except ``INFO`` and ``DEBUG`` (matches
+		the intent of lftomo's default; bug-fixed to use bitwise ``|``).
+		"""
+		if mask is None:
+			mask = LOG_MASK_ALL & ~(LOG.INFO | LOG.DEBUG)
+		path = Path(path)
+		path.parent.mkdir(parents=True, exist_ok=True)
+		self.__logs[name] = (path, mask)
+
+	def attach_func(self, func):
+		"""Run ``func(step, pid)`` for every ``write()`` call (and ``confirm`` / ``prompt``)."""
+		if func not in self.__attached_funcs:
+			self.__attached_funcs.append(func)
+
+	def header(self, out=None):
+		"""Write a column-header line to all configured screens and files."""
+		header_message = f'{"TYPE":6}|{"STEP":20}|   TIMESTAMP   |MEM USAGE|MEM FREE | STATEMENT '
+		self.__special_write(header_message, out)
+
+	def footer(self, out=None, error=None):
+		"""Write a COMPLETED or ERRORED bookend line."""
+		step = "COMPLETED" if error is None else "ERRORED"
+		statement = "" if error is None else str(error)
+		log_level = LOG.STATUS if error is None else LOG.ERROR
+		self.__special_write(self.__log_message(step, statement, log_level), out)
+
+	def start(self, out=None):
+		"""Convenience: column header followed by a ``Script Start`` STATUS line."""
+		self.header(out=out)
+		self.write("Script Start", str(self.script_start), log_level=LOG.STATUS, out=out)
+
+	def write(self, step, statement='', log_level=LOG.TIME, out=None, write_tb=False):
+		"""Emit a formatted log line to all destinations whose mask matches."""
+		for func in self.__attached_funcs:
+			func(step, self.__pid)
+
+		if write_tb:
+			_, _, last_traceback = exc_info()
+			statement = f'{statement}-tb-{last_traceback}'
+
+		message = self.__log_message(step, statement, log_level)
+
+		if out is not None:
+			click.echo(message, file=out, err=(log_level == LOG.ERROR))
+		else:
+			self.__multi_write(message, log_level)
+
+	def confirm(self, step, statement='', log_level=LOG.TIME, out: TextIO = stdout):
+		for func in self.__attached_funcs:
+			func(step, self.__pid)
+		return click.confirm(self.__log_message(step, statement, log_level),
+								err=(log_level == LOG.ERROR))
+
+	def prompt(self, step, statement='', log_level=LOG.TIME, out: TextIO = stdout, default=None):
+		for func in self.__attached_funcs:
+			func(step, self.__pid)
+		return click.prompt(self.__log_message(step, statement, log_level),
+								err=(log_level == LOG.ERROR), default=default)
+
+	def progress(self, step, items, length=None, disp=None, out: TextIO = stdout):
+		"""mctutil-specific: wrap ``click.progressbar`` with a STATUS-styled label."""
+		styled_type = click.style(f'{LOG.STATUS.name:6}', LOG.STATUS.color)
+		return click.progressbar(items, length=length, item_show_func=disp, file=out, show_eta=True,
+									show_pos=True, label=f'{styled_type}|{step[:20]:20}',
+									info_sep='|', width=39, bar_template="%(label)s|%(bar)s|%(info)s|")
+
+	def dump(self, statement, log_level=LOG.INFO, out=None, use_color=False):
+		"""Write a raw statement without the TYPE/STEP/TIMESTAMP/MEM preamble. Attached funcs aren't run."""
+		if use_color:
+			statement = click.style(statement, log_level.color)
+		if out is not None:
+			click.echo(statement, file=out, err=(log_level == LOG.ERROR))
+		else:
+			self.__multi_write(statement, log_level)
+
+	def __log_message(self, step, statement='', log_level=LOG.TIME):
+		styled_type = click.style(f'{log_level.name:6}', log_level.color)
+		return (f'{styled_type}'
+				f'|{step[:20]:20}'
+				f'|{str(datetime.now() - self.script_start).zfill(15)}'
+				f'|{psutil.Process().memory_info().vms // 1024 ** 2:09.2f}MB'
+				f'|{psutil.virtual_memory().available // 1024 ** 2:09.2f}MB'
+				f'|"{statement}"')
+
+	def __special_write(self, message, out=None):
+		# Bug-fix vs. lftomo: write to both stdout and stderr if both are
+		# configured (lftomo's elif chain skipped stderr when stdout was set).
+		if out is not None:
+			click.echo(message, file=out)
+			return
+		if self.__log_screen.get("stdout"):
+			click.echo(message)
+		if self.__log_screen.get("stderr"):
+			click.echo(message, err=True)
+		for path, _flag in self.__logs.values():
+			with open(path, "a") as handle:
+				click.echo(message, file=handle)
+
+	def __multi_write(self, message, log_level):
+		stream_mask = reduce(ior, self.__log_screen.values(), LOG.SILENT)
+		if log_level & stream_mask:
+			stderr_mask = self.__log_screen.get("stderr", LOG.SILENT)
+			err = bool(log_level & stderr_mask)
+			click.echo(message, err=err)
+
+		for path, log_flag in self.__logs.values():
+			if log_level & log_flag:
+				with open(path, "a") as handle:
+					click.echo(message, file=handle)
 
 
-def log(step: str, statement: str = '', log_level: DEBUG = DEBUG.TIME, out: TextIO = stdout,
-		pid: int = psutil.Process().pid):
-	for func in __attached_funcs:
-		func(step, pid)
-	click.echo(__log_message(step, statement, log_level), file=out, err=(log_level == DEBUG.ERROR))
-
-
-def log_progress(step: str, items, length=None, disp=None, out: TextIO = stdout):
-	styled_type = click.style(f'{DEBUG.STATUS.name:6}', DEBUG.STATUS.color)
-	return click.progressbar(items, length=length, item_show_func=disp, file=out, show_eta=True, show_pos=True,
-				label=f'{styled_type}|{step[:20]:20}', info_sep='|', width=39,
-				bar_template="%(label)s|%(bar)s|%(info)s|")
-
-
-def log_confirm(step: str, statement: str = '', log_level: DEBUG = DEBUG.TIME, out: TextIO = stdout,
-				pid: int = psutil.Process().pid):
-	for func in __attached_funcs:
-		func(step, pid)
-	return click.confirm(__log_message(step, statement, log_level), err=(log_level == DEBUG.ERROR))
-
-
-def log_prompt(step: str, statement: str = '', log_level: DEBUG = DEBUG.TIME, out: TextIO = stdout,
-				pid: int = psutil.Process().pid, default=None):
-	for func in __attached_funcs:
-		func(step, pid)
-	return click.prompt(__log_message(step, statement, log_level), err=(log_level == DEBUG.ERROR), default=default)
-
-
-def attach_func(func: callable):
-	"""Attach a function to be called during a logging step."""
-	if func not in __attached_funcs:
-		__attached_funcs.append(func)
-
-
-def cleanup_mem(*shm_objects):
-	from shared.mem import cleanup_mem as shared_cleanup_mem
-
-	return shared_cleanup_mem(*shm_objects)
-
-
-def exit_cleanly(step: str, *shm_objects, return_code: int = 0, statement: str = '', log_level: DEBUG = DEBUG.TIME,
-					out: TextIO = stdout, throw: Exception = None):
-	from shared.mem import exit_cleanly as shared_exit_cleanly
-
-	return shared_exit_cleanly(step, *shm_objects, return_code=return_code, statement=statement,
-								log_level=log_level, out=out, throw=throw)
+log = Logger()

--- a/mctutil/shared/mem.py
+++ b/mctutil/shared/mem.py
@@ -7,7 +7,7 @@ from typing import TextIO
 import numpy as np
 import psutil
 
-from mctutil.shared.log import log, DEBUG, attach_func
+from mctutil.shared.log import log, LOG
 
 NPString = namedtuple("NPString", 'T')
 SinoOrder = namedtuple("SinoOrder", ['Y', 'Theta', 'X'])
@@ -72,9 +72,9 @@ class SharedNP:
 				stop = self.size([buffer_index[-1] + 1])
 				self.__shape = self.__shape._make([len(buffer_index)] + list(self.__shape[1:]))
 			else:
-				log("Shared Memory", "Please use only single contiguous ranges for memory allocation;"
+				log.write("Shared Memory", "Please use only single contiguous ranges for memory allocation;"
 										+ f" {buffer_index} for {self.__name}, shape {self.__shape} failed.",
-										log_level=DEBUG.ERROR)
+										log_level=LOG.ERROR)
 				raise MemoryError
 			return slice(start, stop)
 
@@ -86,22 +86,23 @@ class SharedNP:
 		try:
 			shared_memory.SharedMemory(create=True, size=self.__full_size, name=self.__name)
 		except FileExistsError:
-			log("Shared Memory", f"Shared Memory Name {self.__name} Pre-Existed", log_level=DEBUG.INFO)
+			log.write("Shared Memory", f"Shared Memory Name {self.__name} Pre-Existed", log_level=LOG.INFO)
 			mem = shared_memory.SharedMemory(name=self.__name)
 			if recycle:
 				mem.close()
 				mem.unlink()
 				mem = shared_memory.SharedMemory(create=True, size=self.__full_size, name=self.__name)
-				log("Shared Memory", f"Shared Memory Name {self.__name} Recreated", log_level=DEBUG.INFO)
+				log.write("Shared Memory", f"Shared Memory Name {self.__name} Recreated", log_level=LOG.INFO)
 			elif len(mem.buf) < self.__ar_size:
-				log("Shared Memory", f"Existing {self.__name} Memory Too Small for Array ({len(mem.buf)} vs {self.__ar_size})",
-					log_level=DEBUG.ERROR)
+				log.write("Shared Memory",
+					f"Existing {self.__name} Memory Too Small for Array ({len(mem.buf)} vs {self.__ar_size})",
+					log_level=LOG.ERROR)
 				raise MemoryError
 			else:
 				if len(mem.buf) < self.__full_size:
-					log("Shared Memory", f"Existing {self.__name} Size {len(mem.buf)} Less Than Full Size {self.__full_size}.",
-							log_level=DEBUG.WARN)
-				log("Shared Memory", f"Using Existing {self.__name} Size {len(mem.buf)}", log_level=DEBUG.INFO)
+					log.write("Shared Memory", f"Existing {self.__name} Size {len(mem.buf)} Less Than Full Size {self.__full_size}.",
+							log_level=LOG.WARN)
+				log.write("Shared Memory", f"Using Existing {self.__name} Size {len(mem.buf)}", log_level=LOG.INFO)
 		self.__unlink = True
 
 	def __load(self):
@@ -110,7 +111,7 @@ class SharedNP:
 			self.__sm = shared_memory.SharedMemory(name=self.__name)
 			return np.ndarray(shape=self.__shape, dtype=self.__dtype, buffer=self.__sm.buf[self.__slice])
 		except FileNotFoundError:
-			log("Shared Memory", f"Shared Memory {self.__name} Has Not Been Created", log_level=DEBUG.ERROR)
+			log.write("Shared Memory", f"Shared Memory {self.__name} Has Not Been Created", log_level=LOG.ERROR)
 			return None
 
 	def __branch(self, buffer_index=None, dtype=None, transpose=False, shape=None):
@@ -149,9 +150,9 @@ class SharedNP:
 		self.close()
 		if self.__sm is not None:
 			self.__sm.unlink()
-			log("Shared Memory", f"Shared Memory {self.__name} Unlinked", log_level=DEBUG.STATUS)
+			log.write("Shared Memory", f"Shared Memory {self.__name} Unlinked", log_level=LOG.STATUS)
 		else:
-			log("Shared Memory", f"Shared Memory {self.__name} Is None", log_level=DEBUG.STATUS)
+			log.write("Shared Memory", f"Shared Memory {self.__name} Is None", log_level=LOG.STATUS)
 
 	def transpose(self, order=[1, 0], change_data=False):
 		if change_data:
@@ -213,11 +214,11 @@ class SharedNP:
 		"""Context handler to close shared memory.  Unlinks if this created the memory."""
 		self.close()
 		if self.__unlink:
-			log("Shared Memory", f"Unlinking {self.name}", log_level=DEBUG.INFO)
+			log.write("Shared Memory", f"Unlinking {self.name}", log_level=LOG.INFO)
 			self.unlink()
 		if exc_type is not None:
-			log("Shared Memory", f"Exception ({exc_type}: {exc_value})", log_level=DEBUG.ERROR)
-			log("Shared Memory", traceback, log_level=DEBUG.ERROR)
+			log.write("Shared Memory", f"Exception ({exc_type}: {exc_value})", log_level=LOG.ERROR)
+			log.write("Shared Memory", traceback, log_level=LOG.ERROR)
 
 	def __del__(self):
 		"""Delete closes; unlinks only if this created the memory.."""
@@ -242,7 +243,7 @@ def cleanup_mem(*shm_objects):
 			shm.unlink()
 
 
-def exit_cleanly(step: str, *shm_objects, return_code: int = 0, statement: str = '', log_level: DEBUG = DEBUG.TIME,
+def exit_cleanly(step: str, *shm_objects, return_code: int = 0, statement: str = '', log_level: LOG = LOG.TIME,
 					out: TextIO = stdout, throw: Exception = None):
 	""" Exit while cleaning up shared memory.
 
@@ -250,7 +251,7 @@ def exit_cleanly(step: str, *shm_objects, return_code: int = 0, statement: str =
 		:param shm_objects: Shared memory objects to shut down.
 		:param return_code: Process return code to send.
 	"""
-	log(step, statement, log_level, out)
+	log.write(step, statement, log_level, out)
 	cleanup_mem(*shm_objects)
 
 	sleep(MEM_INTERVAL_TIMER)
@@ -268,7 +269,7 @@ def mem_monitor(mem_file, mem_store, pid):
 			while last_step.strip() not in ["Error Exit", "Script Completion", "Keyboard Exit", "Exit",
 											"Center Find Done", "Scan Path Failure"]:
 				last_step = last_step_arr.tobytes().decode()
-				log(last_step, out=out, pid=pid)
+				log.write(last_step, out=out, pid=pid)
 				sleep(MEM_INTERVAL_TIMER)
 
 
@@ -282,7 +283,7 @@ def init_mem_tracker():
 	last_step = SharedNP(dtype=np.uint8, name=f"last_step_{psutil.Process().pid}", shape=NPString(T=20), create=False)
 	with last_step.create() as last_step_arr:
 		last_step_arr[:] = np.frombuffer("Script Inactive     ".encode(), dtype=last_step.dtype)
-	attach_func(__update_last_step)
+	log.attach_func(__update_last_step)
 	return last_step
 
 

--- a/mctutil/transform/channelize.py
+++ b/mctutil/transform/channelize.py
@@ -6,13 +6,13 @@ import numpy as np
 import tifffile as tf
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 def channelize_file(randomize, source, target_dir, execute=True):
 	target_path = target_dir.joinpath(source.name)
 	if not execute:
-		log.log("Channelize", f"Would write {target_path}", log_level=log.DEBUG.INFO)
+		log.write("Channelize", f"Would write {target_path}", log_level=LOG.INFO)
 		return
 
 	source_data = tf.imread(source)
@@ -32,7 +32,7 @@ def channelize_file(randomize, source, target_dir, execute=True):
 		target_data = np.repeat(source_data, 3).reshape(new_shape)
 
 	tf.imwrite(target_path, target_data.astype(source_data.dtype))
-	log.log("Channelize", f"{target_path} written", log_level=log.DEBUG.STATUS)
+	log.write("Channelize", f"{target_path} written", log_level=LOG.STATUS)
 
 
 @click.command()
@@ -45,7 +45,7 @@ def channelize(randomize, execute, root_path, target_path):
 	if execute:
 		target_path.mkdir(parents=True)
 	else:
-		log.log("Channelize", f"Would create {target_path}", log_level=log.DEBUG.INFO)
+		log.write("Channelize", f"Would create {target_path}", log_level=LOG.INFO)
 	with Pool(12) as pool:
 		pool.starmap(channelize_file,
 					[(randomize, source, target_path, execute) for source in root_path.iterdir()])

--- a/mctutil/transform/convert.py
+++ b/mctutil/transform/convert.py
@@ -6,25 +6,25 @@ import numpy as np
 import tifffile as tf
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.np_convert import np_convert
 
 
 def write_split(source: Path, output_folder: Path, sections: int, dtype: type, compression: bool):
-	log.log("Preload", f"Loading {source.name}")
+	log.write("Preload", f"Loading {source.name}")
 	source_meta = tf.TiffFile(source)
-	log.log("Preload Meta", f"{source_meta}", log_level=log.DEBUG.INFO)
+	log.write("Preload Meta", f"{source_meta}", log_level=LOG.INFO)
 	for k in range(0, len(source_meta.series)):
 		for j in range(0, len(source_meta.series[k].levels)):
 			source_data = tf.imread(source, series=k, level=j)
-			log.log("Loaded", f"Loaded {source.name}: {source_data.shape} (series {j}, level {k})")
+			log.write("Loaded", f"Loaded {source.name}: {source_data.shape} (series {j}, level {k})")
 			split_size = source_data.shape[1] // sections
 			for i in range(0, sections):
 				target_path = output_folder.joinpath(source.with_suffix("").name + f"_s{k}_l{j}_p{i + 1}.tiff")
 				tf.imwrite(target_path,
 							np_convert(dtype, source_data[:, i * split_size: (i + 1) * split_size]),
 							compression=tf.COMPRESSION.LZW if compression else None)
-				log.log("Writing", f"Wrote {target_path}")
+				log.write("Writing", f"Wrote {target_path}")
 
 
 @click.command()
@@ -36,7 +36,7 @@ def write_split(source: Path, output_folder: Path, sections: int, dtype: type, c
 @click.argument("output_folder", type=click.Path(path_type=Path))
 def convert(output_type, horizontal_sections, uncompressed, input_folder, output_folder):
 	output_folder.mkdir(exist_ok=True, parents=True)
-	log.log("Setup", f"Converting each file into {horizontal_sections} {output_type} files.")
+	log.write("Setup", f"Converting each file into {horizontal_sections} {output_type} files.")
 
 	with Pool(24) as pool:
 		pool.starmap(write_split, ([img, output_folder, horizontal_sections, np.dtype(output_type), not uncompressed]

--- a/mctutil/transform/df_write_tiff.py
+++ b/mctutil/transform/df_write_tiff.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sys
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 def _env_path(name: str, default: str) -> Path:
@@ -30,7 +30,7 @@ def set_df_environment():
 		ana_dir.joinpath("Lib\\site-packages\\pywin32_system32"),
 		ors_dir.joinpath("pythonAllUsersExtensions"), user_dir.joinpath("pythonUserExtensions")]])
 
-	log.log("DF Write TIFF", f"Python {sys.version} on {sys.platform}", log_level=log.DEBUG.INFO)
+	log.write("DF Write TIFF", f"Python {sys.version} on {sys.platform}", log_level=LOG.INFO)
 
 
 set_df_environment()
@@ -61,9 +61,9 @@ def df_write_tiff(df_source, df_object, df_title, df_id, execute, outputdir):
 	target = outputdir.joinpath(f"{source.getTitle()}.tif")
 	if execute:
 		tf.imwrite(target, source.getAsNDArray(0))
-		log.log("DF Write TIFF", f"Wrote {target}", log_level=log.DEBUG.STATUS)
+		log.write("DF Write TIFF", f"Wrote {target}", log_level=LOG.STATUS)
 	else:
-		log.log("DF Write TIFF", f"Would write {target}", log_level=log.DEBUG.INFO)
+		log.write("DF Write TIFF", f"Would write {target}", log_level=LOG.INFO)
 
 
 if __name__ == "__main__":

--- a/mctutil/transform/dicom_conv.py
+++ b/mctutil/transform/dicom_conv.py
@@ -4,7 +4,7 @@ import click
 import dicom2jpg
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log
 
 
 @click.command
@@ -16,7 +16,7 @@ def dicom_conv(input_loc: Path, output_loc: Path):
 	path_list = input_loc.iterdir() if input_loc.is_dir() else [input_loc]
 	for path in path_list:
 		dicom2jpg.dicom2tiff(path, output_loc.joinpath(*path.parts[-2:]))
-		log.log("File Written", path.parts[-2:])
+		log.write("File Written", path.parts[-2:])
 
 
 if __name__ == "__main__":

--- a/mctutil/transform/downsample.py
+++ b/mctutil/transform/downsample.py
@@ -6,7 +6,7 @@ import tifffile as tf
 
 
 from mctutil.shared import cli
-from mctutil.shared import log
+from mctutil.shared.log import log
 from mctutil.shared.np_convert import np_convert
 
 
@@ -22,7 +22,7 @@ def downsample(data_dir, output_dir, out_dtype):
 	for path in Path(data_dir).iterdir():
 		in_img = tf.imread(path)
 		tf.imwrite(Path(out_dir, path.name), np_convert(dtype, in_img), dtype=dtype)
-		log.log("File Written", path.name)
+		log.write("File Written", path.name)
 
 
 if __name__ == "__main__":

--- a/mctutil/transform/find_bounds.py
+++ b/mctutil/transform/find_bounds.py
@@ -7,7 +7,7 @@ import numpy as np
 import psutil
 import tifffile as tf
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 count = 0
 start_time = datetime.now()
@@ -18,7 +18,7 @@ def image_bounds(path):
 	global count
 	count += 1
 	if count % 50 == 0:
-		log.log("Find Bounds", f"{count} calculated", log_level=log.DEBUG.INFO)
+		log.write("Find Bounds", f"{count} calculated", log_level=LOG.INFO)
 	return np.array([np.min(x), np.max(x)])
 
 
@@ -26,12 +26,12 @@ def image_bounds(path):
 @click.option("--process-count", "-p", type=click.INT, default=psutil.cpu_count() * 3, help="")
 @click.argument("input-path", type=click.Path(file_okay=False, exists=True, path_type=Path))
 def find_bounds(process_count, input_path):
-	log.log("Find Bounds", f"Scanning {input_path}", log_level=log.DEBUG.STATUS)
+	log.write("Find Bounds", f"Scanning {input_path}", log_level=LOG.STATUS)
 	with ThreadPool(process_count) as pool:
 		bounds = np.array(pool.map(image_bounds, input_path.glob("**/*.tif*")))
 	min_val = np.min(bounds[:, 0])
 	max_val = np.max(bounds[:, 1])
-	log.log("Find Bounds", f"{min_val}:{max_val}", log_level=log.DEBUG.STATUS)
+	log.write("Find Bounds", f"{min_val}:{max_val}", log_level=LOG.STATUS)
 	return min_val, max_val
 
 

--- a/mctutil/transform/hdf_convert.py
+++ b/mctutil/transform/hdf_convert.py
@@ -6,7 +6,7 @@ import click
 from osgeo import gdal
 import tifffile
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 startTime = datetime.now()
 gdal.UseExceptions() 	# Throws many warnings if we don't set whether we want exceptions.
@@ -31,19 +31,19 @@ def image_conv(image_path: Path, target_dir: Path, execute: bool = True):
 	target_path = target_dir.joinpath(image_path.with_suffix(".tiff").name)
 
 	if not execute:
-		log.log("HDF Convert", f"Would convert {image_path} -> {target_path}", log_level=log.DEBUG.INFO)
+		log.write("HDF Convert", f"Would convert {image_path} -> {target_path}", log_level=LOG.INFO)
 		return
 
 	with open(target_dir.parent.joinpath(f"{target_dir.name}.log"), "a") as logfile:
 		src_ds = gdal.Open(str(image_path))
-		log.log("HDF Convert", f"{image_path} read", log_level=log.DEBUG.STATUS)
+		log.write("HDF Convert", f"{image_path} read", log_level=LOG.STATUS)
 		logfile.write(f"{image_path} Read\n")
 
 		out_ds = gdal.Translate('/vsimem/in_memory_output.tif', src_ds, format='GTiff', bandList=[1])
 		out_arr = out_ds.ReadAsArray()
 
 		tifffile.imwrite(target_path, out_arr)
-		log.log("HDF Convert", f"{target_path} written", log_level=log.DEBUG.STATUS)
+		log.write("HDF Convert", f"{target_path} written", log_level=LOG.STATUS)
 		logfile.write(f"{target_path} Written\n")
 
 
@@ -65,13 +65,13 @@ def hdf_convert(target_dir, processes, execute, input):
 		total = len(file_paths)
 
 		if total == 0:
-			log.log("HDF Convert", f"{proj_dir}: No images found, skipping.", log_level=log.DEBUG.WARN)
+			log.write("HDF Convert", f"{proj_dir}: No images found, skipping.", log_level=LOG.WARN)
 			continue
 		else:
 			target_subdir = target_dir.joinpath("tiff_sets", proj_dir.parent.name, proj_dir.name)
-			log.log("HDF Convert",
+			log.write("HDF Convert",
 					f"{proj_dir}: {total} images found; writing to {target_subdir}",
-					log_level=log.DEBUG.STATUS)
+					log_level=LOG.STATUS)
 			if execute:
 				target_subdir.mkdir(parents=True, exist_ok=True)
 
@@ -86,9 +86,9 @@ def hdf_convert(target_dir, processes, execute, input):
 			with Pool(processes=processes) as pool:
 				pool.starmap(image_conv, [(file_path, target_subdir, execute) for file_path in file_paths])
 
-	log.log("HDF Convert",
+	log.write("HDF Convert",
 			f"HDF Convert {'complete' if execute else 'planned'}: {datetime.now() - startTime}",
-			log_level=log.DEBUG.STATUS)
+			log_level=LOG.STATUS)
 
 
 if __name__ == '__main__':

--- a/mctutil/transform/mesh.py
+++ b/mctutil/transform/mesh.py
@@ -9,7 +9,7 @@ import click
 import igneous.task_creation as tc
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -21,9 +21,9 @@ def mesh(proj_dir, layer_path, execute):
 	mip = 0
 
 	if not execute:
-		log.log("Mesh",
+		log.write("Mesh",
 				f"Would create meshing tasks for {layer_path} (mip={mip}, shape=512^3) and follow with manifest tasks",
-				log_level=log.DEBUG.INFO)
+				log_level=LOG.INFO)
 		return
 
 	with LocalTaskQueue(parallel=8) as tq:
@@ -44,13 +44,13 @@ def mesh(proj_dir, layer_path, execute):
 			sharded=False,					# generate intermediate shard fragments for later processing into sharded format
 		)
 		tq.insert_all(tasks)
-	log.log("Mesh", "create_meshing_tasks complete", log_level=log.DEBUG.STATUS)
+	log.write("Mesh", "create_meshing_tasks complete", log_level=LOG.STATUS)
 
 	with LocalTaskQueue(parallel=8) as tq:
 		tasks = tc.create_mesh_manifest_tasks(layer_path, magnitude=3) 	# Second Pass
 		tq.insert_all(tasks)
 
-	log.log("Mesh", "create_mesh_manifest_tasks complete", log_level=log.DEBUG.STATUS)
+	log.write("Mesh", "create_mesh_manifest_tasks complete", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/transform/ng.py
+++ b/mctutil/transform/ng.py
@@ -9,7 +9,7 @@ import json
 import tifffile
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -29,14 +29,14 @@ from mctutil.shared import log
 @click.option('-o', '--output-location', type=click.Path(), required=True)
 def neuroglance(chunk_size, resolution, segmentation, strip_gz, input_path, metadata_info, compress_info,
 				output_location):
-	log.log("Neuroglance", f"Input folder: {input_path}", log_level=log.DEBUG.STATUS)
+	log.write("Neuroglance", f"Input folder: {input_path}", log_level=LOG.STATUS)
 	image_paths = natsorted(Path(input_path).glob("**/*.tif*"))
 
 	memmap_ = tifffile.memmap(image_paths[0])
 	size = [memmap_.shape[1], memmap_.shape[0], len(image_paths)]
 	dtype_ = str(memmap_.dtype)
 
-	log.log("Neuroglance", f"Volume size is {size}, datatype is {dtype_}", log_level=log.DEBUG.STATUS)
+	log.write("Neuroglance", f"Volume size is {size}, datatype is {dtype_}", log_level=LOG.STATUS)
 
 	if segmentation:
 		json_metadata = {

--- a/mctutil/transform/normalize.py
+++ b/mctutil/transform/normalize.py
@@ -8,7 +8,7 @@ import psutil
 import tifffile as tf
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.cli import FRANGE
 from mctutil.shared.mem import SharedNP, ProjOrder
 from mctutil.shared.np_convert import np_convert
@@ -29,15 +29,15 @@ def normalize(image_mem, index, bottom_threshold, top_threshold, thread_max):
 		floor = np.percentile(image, bottom_threshold)
 		ceiling = np.percentile(image, top_threshold)
 
-		log.log('Normalization',
+		log.write('Normalization',
 			f"{np.min(image)}-{np.max(image)}: {bottom_threshold}-{top_threshold} is {floor:.4g}-{ceiling:.4g}",
-			log_level=log.DEBUG.INFO)
+			log_level=LOG.INFO)
 
 		with Pool(thread_max) as pool:
 			pool.starmap(norm_helper, [(image_mem, i, floor, ceiling) for i in index])
-		log.log('Normalization',
+		log.write('Normalization',
 				f"{bottom_threshold} to {top_threshold}: {floor:.4g} to {ceiling:.4g} {(ceiling - floor):.4g}",
-				log_level=log.DEBUG.INFO)
+				log_level=LOG.INFO)
 
 
 def convert(source_mem, target_mem, i, j):
@@ -61,9 +61,9 @@ def mem_write(mem: SharedNP, path: PathLike, i, dtype, execute=True):
 	with mem[i] as out_data:
 		if execute:
 			tf.imwrite(path, np_convert(dtype, out_data), dtype=dtype)
-			log.log("File Written", path.name)
+			log.write("File Written", path.name)
 		else:
-			log.log("Dry Run", f"Would write {path.name}")
+			log.write("Dry Run", f"Would write {path.name}")
 
 
 @click.command()
@@ -83,27 +83,27 @@ def norm(normalize_over, data_dir, output_dir, processes, execute):
 	inputs = sorted([x for x in Path(data_dir).iterdir() if ".tif" in x.name])
 	batched_input = list(batch(inputs, processes))
 
-	log.log("Initialize", "Inputs Batched")
+	log.write("Initialize", "Inputs Batched")
 
 	with tf.TiffFile(inputs[0]) as tif:
 		mem_shape = ProjOrder(processes, tif.pages[0].shape[0], tif.pages[0].shape[1])
 		dtype = tif.pages[0].dtype
 
-	log.log("Initialize", "Tiff Dimensions Fetched")
+	log.write("Initialize", "Tiff Dimensions Fetched")
 
 	with SharedNP('Normalize_Mem', np.float32, mem_shape, create=True) as norm_mem:
 		for input_set in batched_input:
 			active_indices = list(range(len(input_set)))
 			with Pool(processes) as pool:
 				pool.starmap(memreader, [(norm_mem, i, input_set[i]) for i in active_indices])
-			log.log("Image Load", f"{len(active_indices)} Images Loaded")
+			log.write("Image Load", f"{len(active_indices)} Images Loaded")
 			normalize(norm_mem, active_indices, normalize_over.start, normalize_over.stop, processes)
 			with Pool(processes) as pool:
 				pool.starmap(
 					mem_write,
 					[(norm_mem, Path(output_dir, input_set[i].name), i, dtype, execute) for i in active_indices],
 				)
-			log.log("Image Writing", f"{len(active_indices)} Images {'Written' if execute else 'Planned'}")
+			log.write("Image Writing", f"{len(active_indices)} Images {'Written' if execute else 'Planned'}")
 
 
 if __name__ == '__main__':

--- a/mctutil/transform/quickgunzip.py
+++ b/mctutil/transform/quickgunzip.py
@@ -5,7 +5,7 @@ import shutil
 import brotli
 import click
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -26,7 +26,7 @@ def gunzip(root_path, target_path):
 				else:
 					shutil.copy(fname, target_file)
 			except BaseException:
-				log.log("Quick Gunzip", f"Failed file: {fname}|{target_file}", log_level=log.DEBUG.ERROR)
+				log.write("Quick Gunzip", f"Failed file: {fname}|{target_file}", log_level=LOG.ERROR)
 
 
 if __name__ == '__main__':

--- a/mctutil/transform/simple_noise.py
+++ b/mctutil/transform/simple_noise.py
@@ -7,11 +7,11 @@ import numpy as np
 import psutil
 import tifffile as tf
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 def denoise_threshold(input_paths, output_path, threshold):
-	log.log("Simple Denoise", f"Threshold inputs: {input_paths}", log_level=log.DEBUG.INFO)
+	log.write("Simple Denoise", f"Threshold inputs: {input_paths}", log_level=LOG.INFO)
 	base_data = np.array([tf.imread(infile) for infile in input_paths]).astype(np.int32)
 
 	floor = np.min(base_data)
@@ -52,11 +52,11 @@ def simple_denoise(threshold, area, num_processes, flat_denoise, inputdir, outpu
 
 	with Pool(num_processes) as pool:
 		if flat_denoise:
-			log.log("Simple Denoise", "Mode: flat", log_level=log.DEBUG.STATUS)
+			log.write("Simple Denoise", "Mode: flat", log_level=LOG.STATUS)
 			pool.starmap(denoise_flat, [(input_paths[i - 1: i + 2], outputdir.joinpath(input_paths[i].name), threshold)
 										for i in range(1, len(input_paths) - 1)])
 		else:
-			log.log("Simple Denoise", f"Mode: threshold ({len(input_paths)} inputs)", log_level=log.DEBUG.STATUS)
+			log.write("Simple Denoise", f"Mode: threshold ({len(input_paths)} inputs)", log_level=LOG.STATUS)
 			pool.starmap(denoise_threshold, [(input_paths[i - 1: i + 2], outputdir.joinpath(input_paths[i].name), threshold)
 											for i in range(1, len(input_paths) - 1)])
 

--- a/mctutil/transform/sinogram.py
+++ b/mctutil/transform/sinogram.py
@@ -11,7 +11,7 @@ from skimage.restoration import denoise_nl_means, estimate_sigma
 import tifffile as tf
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared import cli
 from mctutil.shared.io_helpers import FLAT, distribute_read
 from mctutil.shared.mem import SharedNP, ProjOrder, SinoOrder
@@ -49,9 +49,9 @@ def sino_write(sino_mem: SharedNP, path: PathLike, i, out_type: cli.NumpyCLI = N
 				tf.imwrite(path, sino[i, :, :])
 			else:
 				tf.imwrite(path, out_type.convert_ar(sino[i, :, :]))
-			log.log("File Written", str(path))
+			log.write("File Written", str(path))
 		else:
-			log.log("Dry Run", f"Would write {path}")
+			log.write("Dry Run", f"Would write {path}")
 
 
 def image_bounds(sino_mem: SharedNP, i: int = None):
@@ -60,7 +60,7 @@ def image_bounds(sino_mem: SharedNP, i: int = None):
 			return np.array([np.min(sino), np.max(sino)])
 	with sino_mem[i] as sino:
 		if np.max(sino) > 2:
-			log.log("Bounds Check", f"Peak value {np.max(sino):.4g}", log_level=log.DEBUG.INFO)
+			log.write("Bounds Check", f"Peak value {np.max(sino):.4g}", log_level=LOG.INFO)
 		return np.array([np.min(sino), np.max(sino)])
 
 
@@ -138,7 +138,7 @@ def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: i
 
 	sino_shape = SinoOrder(process_count, len(image_paths), pj["x"])
 	proj_shape = ProjOrder(len(image_paths), process_count, pj["x"])
-	log.log("Setup", f"{pj}")
+	log.write("Setup", f"{pj}")
 
 	with (
 		SharedNP(
@@ -157,7 +157,7 @@ def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: i
 		for x in sino_split:
 			window = range(x, min(x + process_count, sino_split.stop))
 			internal_window = range(0, len(window))
-			log.log("Cycle Start", f"Window {window}; Internal {internal_window}; Shape {sino_shape} from {proj_shape}")
+			log.write("Cycle Start", f"Window {window}; Internal {internal_window}; Shape {sino_shape} from {proj_shape}")
 			distribute_read(
 				input_mem,
 				pj,
@@ -167,7 +167,7 @@ def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: i
 				thread_max=process_count,
 				sino_order=False,
 			)
-			log.log("Files Read", f"Window {window}; Shape {proj_shape}")
+			log.write("Files Read", f"Window {window}; Shape {proj_shape}")
 			with Pool(process_count) as pool:
 				pool.starmap(
 					weighted_normalize,
@@ -182,10 +182,10 @@ def run_full(input_dir: Path, output_dir: Path, flat_dir: Path, process_count: i
 					sino_write,
 					[(sino_mem, output_paths[i + window.start], i, None, execute) for i in internal_window],
 				)
-			log.log(
+			log.write(
 				"Files Written",
 				f"{output_dir} : {window} ({'written' if execute else 'planned'})",
-				log.DEBUG.TIME,
+				LOG.TIME,
 			)
 
 
@@ -211,7 +211,7 @@ def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: 
 
 	sino_shape = SinoOrder(process_count, pj["y"], pj["x"])
 	bounds = []
-	log.log("Setup", f"{pj}")
+	log.write("Setup", f"{pj}")
 
 	if min_val is None or max_val is None:
 		with SharedNP(f"sino_{segment_id}", internal_dtype, sino_shape, create=True) as sino_mem:
@@ -224,7 +224,7 @@ def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: 
 		bounds = np.asarray(bounds)
 		min_val = np.min(bounds[:, 0])
 		max_val = np.max(bounds[:, 1])
-		log.log("Final Bounds Calculated", f"{min_val} : {max_val}", log.DEBUG.TIME)
+		log.write("Final Bounds Calculated", f"{min_val} : {max_val}", LOG.TIME)
 
 	with SharedNP(f"sino_{segment_id}", internal_dtype, sino_shape, create=True) as sino_mem:
 		for x in range(0, len(image_paths), process_count):
@@ -239,10 +239,10 @@ def run_preproc(input_dir: Path, output_dir: Path, process_count: int, min_val: 
 					sino_write,
 					[(sino_mem, output_paths[i + window.start], i, None, execute) for i in internal_window],
 				)
-			log.log(
+			log.write(
 				"Files Written",
 				f"{output_dir} : {window} ({'written' if execute else 'planned'})",
-				log.DEBUG.TIME,
+				LOG.TIME,
 			)
 
 

--- a/mctutil/transform/stitch.py
+++ b/mctutil/transform/stitch.py
@@ -6,7 +6,7 @@ import numpy as np
 import tifffile as tf
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared.mem import SharedNP, ProjOrder
 
 
@@ -98,7 +98,7 @@ class SampleSet():
 def stitch_single(samples, overlaps, new_dim, stitch_output, x, execute=True):
 	output_path = Path(stitch_output, f"AAA590_Stitched_{x}.tif")
 	if not execute:
-		log.log("Stitch", f"Would write {output_path}", log_level=log.DEBUG.INFO)
+		log.write("Stitch", f"Would write {output_path}", log_level=LOG.INFO)
 		return
 
 	stitched = np.zeros(new_dim, dtype=np.uint16)
@@ -130,21 +130,21 @@ def stitch_samples(samples, overlaps, stitch_output, execute=True):
 	for s in samples:
 		s.del_proj()
 
-	log.log("Dimension", new_dim)
+	log.write("Dimension", new_dim)
 
 	if execute:
 		Path(stitch_output).mkdir(parents=True, exist_ok=True)
 	else:
-		log.log("Stitch", f"Would create {stitch_output}", log_level=log.DEBUG.INFO)
+		log.write("Stitch", f"Would create {stitch_output}", log_level=LOG.INFO)
 
-	log.log("Output Dir", stitch_output)
+	log.write("Output Dir", stitch_output)
 
 	with Pool(50) as pool:
 		pool.starmap(stitch_single,
 					[(samples, overlaps, new_dim, stitch_output, x, execute)
 						for x in range(len(samples[0].projs))])
 
-	log.log("Stitching Complete",
+	log.write("Stitching Complete",
 			f"{len(samples[0].projs)} projections {'stitched' if execute else 'planned'}")
 
 
@@ -165,19 +165,19 @@ def stitch(sample, top_stitch, stitch_range, stitch_output, execute):
 	for s in sample:
 		s.half_width = target_width
 
-	log.log("Proj Shape", f"HW: {target_width}; P: {[s.proj.shape for s in sample]}")
+	log.write("Proj Shape", f"HW: {target_width}; P: {[s.proj.shape for s in sample]}")
 
 	# Stich the samples in reverse order if we're stitching starting at the top; simpler this way.
 	if top_stitch:
 		sample.reverse()
-		log.log("Reverse", "Reversed to handle top/bottom stitching.")
+		log.write("Reverse", "Reversed to handle top/bottom stitching.")
 
 	overlaps = []
 	stitch_scope = range(20, int(sample[0].proj.shape[0] * stitch_range))
 	for y in range(len(sample) - 1):
 		std_set = [(x, np.std(np.divide(sample[y].proj_bot(x), sample[y + 1].proj_top(x)))) for x in stitch_scope]
 		std_set.sort(key=lambda x: x[1])
-		log.log("Overlap", f"{std_set[0]}")
+		log.write("Overlap", f"{std_set[0]}")
 
 		overlaps.append(std_set[0][0])
 

--- a/mctutil/transform/transform.py
+++ b/mctutil/transform/transform.py
@@ -10,7 +10,7 @@ import tifffile as tf
 from tomopy import circ_mask
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared import cli
 from mctutil.shared.cli import FRANGE, CROP_NUMBER
 from mctutil.shared.mem import SharedNP, ProjOrder
@@ -29,13 +29,13 @@ def normalize(image_mem, part, floor, ceiling):
 def normalize_calc(image_mem, index, bottom_threshold, top_threshold, slice):
 	with image_mem[index] as image:
 		im_part = (np.s_[:],) + slice
-		log.log("Normalize Setup", f"{image.shape}:{im_part}")
+		log.write("Normalize Setup", f"{image.shape}:{im_part}")
 		floor = np.percentile(image[im_part], bottom_threshold)
 		ceiling = np.percentile(image[im_part], top_threshold)
-		log.log("Normalization Setup", f"{image.dtype}:{image.dtype.type}")
-		log.log('Normalization Setup',
+		log.write("Normalization Setup", f"{image.dtype}:{image.dtype.type}")
+		log.write('Normalization Setup',
 			f"{np.min(image)}-{np.max(image)}: {bottom_threshold}-{top_threshold} is {floor:.4g}-{ceiling:.4g}",
-			log_level=log.DEBUG.INFO)
+			log_level=LOG.INFO)
 
 	return floor, ceiling
 
@@ -61,14 +61,14 @@ def memreader(mem, i, path):
 def mem_write(mem: SharedNP, path: PathLike, i, xy_slice, dtype, compression):
 	"""Writes to disk in distributed fashion."""
 	with mem[i] as out_data:
-		log.log("Write Target", f"{path}")
+		log.write("Write Target", f"{path}")
 		tf.imwrite(path, np_convert(dtype, out_data[xy_slice]), dtype=dtype, compression=compression)
 
 
 def bin_write(mem: SharedNP, path: PathLike, i: int, xy_slice, dtype, bin_power: int, compression: int):
 	"""Bins data via linear interpolation in the x-y dimension."""
 	with mem[i] as out_data:
-		log.log("Write Target", f"{path}")
+		log.write("Write Target", f"{path}")
 		new_shape = (out_data.shape[0] / 2, out_data.shape[1] / 2)
 		resized = cv2.resize(out_data[xy_slice], new_shape, interpolation=cv2.INTER_AREA)
 		tf.imwrite(path, np_convert(dtype, resized), dtype=dtype, compression=compression)
@@ -109,7 +109,7 @@ def norm(  # noqa: C901
 	normalize_interval = int(np.ceil(len(inputs) / processes))
 	batched_input = list(batch(inputs, processes, mips_offset))
 
-	log.log("Initialize", f"Inputs Batched; Normalize Interval {normalize_interval}")
+	log.write("Initialize", f"Inputs Batched; Normalize Interval {normalize_interval}")
 
 	with tf.TiffFile(inputs[0]) as tif:
 		mem_shape = ProjOrder(processes + mips_offset, tif.pages[0].shape[0], tif.pages[0].shape[1])
@@ -124,9 +124,9 @@ def norm(  # noqa: C901
 			out_dim = np.s_[int(dim[0] * top_trim):int(dim[0] * (1 - bottom_trim)),
 				int(dim[1] * left_trim):int(dim[1] * (1 - right_trim))]
 
-		log.log("Dimensions", f"{dim}-{out_dim}")
+		log.write("Dimensions", f"{dim}-{out_dim}")
 
-	log.log("Initialize", "Tiff Dimensions Fetched")
+	log.write("Initialize", "Tiff Dimensions Fetched")
 
 	if circ_mask_ratio:
 		actual_start = normalize_over.start + 100 * (1.0 - np.pi * ((circ_mask_ratio / 2) ** 2))
@@ -136,17 +136,17 @@ def norm(  # noqa: C901
 	with SharedNP('Normalize_Mem', np.float32, mem_shape, create=True) as norm_mem:
 		with Pool(processes) as pool:
 			image_count = len(inputs) // normalize_interval
-			log.log("Image Load", f"{len(inputs)}:{normalize_interval}:{processes}:{len(inputs) // normalize_interval}")
+			log.write("Image Load", f"{len(inputs)}:{normalize_interval}:{processes}:{len(inputs) // normalize_interval}")
 
 			pool.starmap(memreader, [(norm_mem, i, inputs[j]) for i, j in enumerate(range(0, len(inputs), normalize_interval))])
-			log.log("Image Load",
+			log.write("Image Load",
 				f"{len(range(0, len(inputs), len(inputs) // normalize_interval))}|{normalize_interval}"
 				" Images Loaded For Normalization")
 
 			if circ_mask_ratio:
 				with norm_mem as mips_mem:
 					circ_mask(mips_mem, axis=0, ratio=circ_mask_ratio, val=np.min(mips_mem[0:image_count]))
-				log.log("Image Masking", f"Images Masked at {circ_mask_ratio}")
+				log.write("Image Masking", f"Images Masked at {circ_mask_ratio}")
 
 			floor, ceiling = normalize_calc(norm_mem, np.s_[0:image_count], actual_start, normalize_over.stop, np.s_[:, :])
 
@@ -156,15 +156,15 @@ def norm(  # noqa: C901
 			try:
 				with Pool(processes) as pool:
 					pool.starmap(memreader, [(norm_mem, i, input_set[i]) for i in indices])
-				log.log("Image Load", f"{len(indices)}|{len(input_set)} Images Loaded")
+				log.write("Image Load", f"{len(indices)}|{len(input_set)} Images Loaded")
 			except Exception as ex:
-				log.log("Image Load", f"Fail: {ex}")
+				log.write("Image Load", f"Fail: {ex}")
 				continue
 
 			if circ_mask_ratio:
 				with norm_mem as mips_mem:
 					circ_mask(mips_mem, axis=0, ratio=circ_mask_ratio, val=floor)
-				log.log("Image Masking", f"Images Masked at {circ_mask_ratio}")
+				log.write("Image Masking", f"Images Masked at {circ_mask_ratio}")
 
 			if mips > 1:
 				with norm_mem as mips_mem:
@@ -178,15 +178,15 @@ def norm(  # noqa: C901
 			with Pool(processes) as pool:
 				pool.starmap(normalize, [(norm_mem, i, floor, ceiling) for i in indices[mips_offset:]])
 
-			log.log("Image Normalization",
+			log.write("Image Normalization",
 				f"{len(indices[mips_offset:])} Images Normalized at {floor:.4g} to {ceiling:.4g} over {(ceiling - floor):.4g}")
 
 			with Pool(processes) as pool:
 				pool.starmap(mem_write, [(norm_mem, Path(output_dir, input_set[i].name), i, out_dim, out_dtype.nptype, compression)
 								for i in indices[mips_offset:]])
 
-			log.log("Image Writing", f"{len([i for i in indices[mips_offset:]])} Images Written")
-	log.log("Complete")
+			log.write("Image Writing", f"{len([i for i in indices[mips_offset:]])} Images Written")
+	log.write("Complete")
 
 
 if __name__ == '__main__':

--- a/mctutil/transform/transpose.py
+++ b/mctutil/transform/transpose.py
@@ -7,7 +7,7 @@ import psutil
 import tifffile as tf
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log
 from mctutil.shared.io_helpers import byteread_helper
 from mctutil.shared.mem import SharedNP, ReconOrder
 
@@ -74,7 +74,7 @@ def transpose_stack(mode, path, stack_start, stack_levels, pixel_shift, out_name
 
 	recon_dtype, recon_shape, base_offset = get_details(path, stack_levels)
 	im_list = sorted(list(Path(path).iterdir()))
-	log.log("Setup", f"Shape {recon_shape}; Type {recon_dtype}; offset {base_offset}")
+	log.write("Setup", f"Shape {recon_shape}; Type {recon_dtype}; offset {base_offset}")
 	with SharedNP("Tranpose_Source", recon_dtype, recon_shape, create=True) as tp_mem:
 		itemsize = np.dtype(recon_dtype).itemsize
 		source_offset = base_offset + recon_shape.X * itemsize * stack_start
@@ -82,7 +82,7 @@ def transpose_stack(mode, path, stack_start, stack_levels, pixel_shift, out_name
 		line_size = recon_shape.X * itemsize
 		chunk_size = line_size * recon_shape.Z
 
-		log.log("Setup", f"Itemsize {itemsize}; Offset {source_offset}; Line Size {line_size}")
+		log.write("Setup", f"Itemsize {itemsize}; Offset {source_offset}; Line Size {line_size}")
 
 		with Pool(psutil.cpu_count()) as pool:
 			def get_offset(i):
@@ -92,14 +92,14 @@ def transpose_stack(mode, path, stack_start, stack_levels, pixel_shift, out_name
 			pool.starmap(byteread_helper, [(tp_mem.name, im_list[i], recon_dtype, get_offset(i), chunk_size)
 										for i in range(len(im_list))])
 
-		log.log("Images Loaded")
+		log.write("Images Loaded")
 		Path(out_path).mkdir(parents=True, exist_ok=True)
 
 		with Pool(psutil.cpu_count()) as pool:
 			pool.starmap(transpose_write, [(tp_mem, Path(out_path, f"{out_name}_{i}.tif"), i)
 										for i in range(recon_shape.Z)])
 
-		log.log("Images Written")
+		log.write("Images Written")
 
 
 if __name__ == "__main__":

--- a/mctutil/transform/trim.py
+++ b/mctutil/transform/trim.py
@@ -5,7 +5,8 @@ import click
 import tifffile as tf
 
 
-from mctutil.shared import cli, log
+from mctutil.shared import cli
+from mctutil.shared.log import log, LOG  # noqa: F401
 
 
 def write_crop(input, output, crop, compress, execute=True):
@@ -15,9 +16,9 @@ def write_crop(input, output, crop, compress, execute=True):
 			tf.imwrite(output, img[crop], compression=8)
 		else:
 			tf.imwrite(output, img[crop])
-		log.log("File Written", f"{output.name}: ({img.shape}>{crop})")
+		log.write("File Written", f"{output.name}: ({img.shape}>{crop})")
 	else:
-		log.log("Dry Run", f"Would write {output.name}: ({img.shape}>{crop})")
+		log.write("Dry Run", f"Would write {output.name}: ({img.shape}>{crop})")
 
 
 @click.command

--- a/mctutil/transform/uncompress.py
+++ b/mctutil/transform/uncompress.py
@@ -4,7 +4,7 @@ import click
 from natsort import natsorted
 import tifffile as tf
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 
 @click.command()
@@ -21,10 +21,10 @@ def uncompress(execute: bool, image_path: Path):
 		if execute:
 			image = tf.imread(im_path)
 			tf.imwrite(im_path, image, compression=None)
-			log.log("Uncompress", f"Rewrote {im_path}", log_level=log.DEBUG.STATUS)
+			log.write("Uncompress", f"Rewrote {im_path}", log_level=LOG.STATUS)
 		else:
-			log.log("Uncompress", f"Would rewrite {im_path}", log_level=log.DEBUG.INFO)
-	log.log("Uncompress", f"{len(images)} files {'rewritten' if execute else 'planned'}", log_level=log.DEBUG.STATUS)
+			log.write("Uncompress", f"Would rewrite {im_path}", log_level=LOG.INFO)
+	log.write("Uncompress", f"{len(images)} files {'rewritten' if execute else 'planned'}", log_level=LOG.STATUS)
 
 
 if __name__ == "__main__":

--- a/mctutil/transport/cv_import.py
+++ b/mctutil/transport/cv_import.py
@@ -8,16 +8,16 @@ import numpy as np
 import psutil
 import tifffile
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 from mctutil.shared import cli
 
 
 def fetch_slices(remote, use_https, region, bin_power, output_dir, execute=True):
-	log.log("Fetching Slices", f"{remote}: {region} with {bin_power}")
+	log.write("Fetching Slices", f"{remote}: {region} with {bin_power}")
 	if not execute:
-		log.log("Fetching Slices",
+		log.write("Fetching Slices",
 				f"Would fetch slices {region[0].start}..{region[0].stop} to {output_dir}",
-				log_level=log.DEBUG.INFO)
+				log_level=LOG.INFO)
 		return
 	vol = CloudVolume(remote, mip=bin_power, use_https=use_https, progress=True)
 	for i, slice_data in enumerate(vol[region], start=region[0].start):
@@ -32,7 +32,7 @@ def bin_slices(base_slice, bin_power, base_dim):
 			new_start = 0 if slice_dim.start is None else slice_dim.start // (2 ** bin_power)
 			new_stop = base_dim[i] if slice_dim.stop is None else slice_dim.stop // (2 ** bin_power)
 			out_slice += (np.s_[new_start: new_stop], )
-		log.log("Slice Calculation", out_slice)
+		log.write("Slice Calculation", out_slice)
 		return out_slice
 	else:
 		return base_slice
@@ -52,7 +52,7 @@ def bin_slices(base_slice, bin_power, base_dim):
 				help="Whether to actually fetch and write slices or just plan the work.")
 @click.argument("output-dir")
 def cloudvolume_fetch(cloud_url, cloud_slice, resolution, bin_power, use_https, num_processes, execute, output_dir):
-	log.log("Start")
+	log.write("Start")
 
 	cloud_slice = bin_slices(cloud_slice, bin_power,
 							CloudVolume(cloud_url, mip=bin_power, use_https=use_https, progress=True).shape)
@@ -65,14 +65,14 @@ def cloudvolume_fetch(cloud_url, cloud_slice, resolution, bin_power, use_https, 
 	if execute:
 		output_dir.mkdir(parents=True, exist_ok=True)
 	else:
-		log.log("Cloudvolume Fetch", f"Would create {output_dir}", log_level=log.DEBUG.INFO)
+		log.write("Cloudvolume Fetch", f"Would create {output_dir}", log_level=LOG.INFO)
 
 	with Pool(num_processes) as pool:
 		pool.starmap(fetch_slices,
 			[(cloud_url, use_https, (np.s_[i:min(i + batch_size, cloud_slice[0].stop)],) + cloud_slice[1:],
 				bin_power, output_dir, execute) for i in range(cloud_slice[0].start, cloud_slice[0].stop, batch_size)])
 
-	log.log("Complete")
+	log.write("Complete")
 
 
 if __name__ == '__main__':

--- a/mctutil/transport/s3upload.py
+++ b/mctutil/transport/s3upload.py
@@ -9,7 +9,7 @@ import click
 import igneous.task_creation as tc
 
 
-from mctutil.shared import log
+from mctutil.shared.log import log, LOG
 
 _session = None
 
@@ -23,7 +23,7 @@ def _get_session():
 
 def upload_file_to_s3(file_path, key, bucket_name, content_encoding, execute=True):
 	if not execute:
-		log.log("S3 Upload", f"Would upload {file_path} -> s3://{bucket_name}/{key}", log_level=log.DEBUG.INFO)
+		log.write("S3 Upload", f"Would upload {file_path} -> s3://{bucket_name}/{key}", log_level=LOG.INFO)
 		return
 
 	s3 = _get_session().client('s3')
@@ -31,9 +31,9 @@ def upload_file_to_s3(file_path, key, bucket_name, content_encoding, execute=Tru
 		try:
 			s3.put_object(Bucket=bucket_name, Key=f"{key}/")
 		except ClientError as e:
-			log.log("S3 Upload", f"ClientError: {e.response}", log_level=log.DEBUG.ERROR)
+			log.write("S3 Upload", f"ClientError: {e.response}", log_level=LOG.ERROR)
 		except Exception as e:
-			log.log("S3 Upload", f"{e}", log_level=log.DEBUG.ERROR)
+			log.write("S3 Upload", f"{e}", log_level=LOG.ERROR)
 	else:  # Handle file
 		extra_args = {}
 		if content_encoding is not None:
@@ -41,10 +41,10 @@ def upload_file_to_s3(file_path, key, bucket_name, content_encoding, execute=Tru
 		try:
 			s3.upload_file(file_path, bucket_name, str(key), ExtraArgs=extra_args)
 		except ClientError as e:
-			log.log("S3 Upload", f"ClientError: {e.response}", log_level=log.DEBUG.ERROR)
+			log.write("S3 Upload", f"ClientError: {e.response}", log_level=LOG.ERROR)
 		except Exception as e:
-			log.log("S3 Upload", f"{e}", log_level=log.DEBUG.ERROR)
-	log.log("S3 Upload", f"uploaded: {key}", log_level=log.DEBUG.STATUS)
+			log.write("S3 Upload", f"{e}", log_level=LOG.ERROR)
+	log.write("S3 Upload", f"uploaded: {key}", log_level=LOG.STATUS)
 
 
 def upload_folder_to_s3_parallel(folder_path, target_folder, bucket_name, num_processes, execute=True):
@@ -73,20 +73,20 @@ def s3upload(bucket_prefix, bucket_name, process_count, mesh, execute, source_fo
 
 	target_full = bucket_prefix.joinpath(target_folder)
 
-	log.log("S3 Upload", f"target bucket: {bucket_name}", log_level=log.DEBUG.STATUS)
-	log.log("S3 Upload", f"target folder: {target_full}", log_level=log.DEBUG.STATUS)
+	log.write("S3 Upload", f"target bucket: {bucket_name}", log_level=LOG.STATUS)
+	log.write("S3 Upload", f"target folder: {target_full}", log_level=LOG.STATUS)
 
 	if execute:
 		s3 = _get_session().client('s3')
 		s3.put_object(Bucket=bucket_name, Key=f"{target_full}/")
 	else:
-		log.log("S3 Upload", f"Would create prefix s3://{bucket_name}/{target_full}/", log_level=log.DEBUG.INFO)
+		log.write("S3 Upload", f"Would create prefix s3://{bucket_name}/{target_full}/", log_level=LOG.INFO)
 
 	upload_folder_to_s3_parallel(source_folder, target_full, bucket_name, num_processes=process_count, execute=execute)
 
 	if mesh:
 		mesh_path = f"precomputed://s3://{bucket_name}/{target_full}"
-		log.log("S3 Upload", f"full remote path: {mesh_path}", log_level=log.DEBUG.STATUS)
+		log.write("S3 Upload", f"full remote path: {mesh_path}", log_level=LOG.STATUS)
 		if execute:
 			tq = LocalTaskQueue(parallel=process_count // 4)
 			tq.insert(tc.create_meshing_tasks(mesh_path, mip=0))
@@ -94,7 +94,7 @@ def s3upload(bucket_prefix, bucket_name, process_count, mesh, execute, source_fo
 			tq.insert(tc.create_unsharded_multires_mesh_tasks(mesh_path, num_lod=4))
 			tq.execute()
 		else:
-			log.log("S3 Upload", f"Would mesh {mesh_path}", log_level=log.DEBUG.INFO)
+			log.write("S3 Upload", f"Would mesh {mesh_path}", log_level=LOG.INFO)
 
 
 if __name__ == '__main__':

--- a/tests/test_phase5_real_behavior.py
+++ b/tests/test_phase5_real_behavior.py
@@ -35,7 +35,7 @@ def test_trim_crops_xy_and_z_ranges(load_module, tmp_path, monkeypatch):
 	module = load_module("mctutil/transform/trim.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
 	monkeypatch.setattr(module.log, "start", lambda: None)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 
 	input_dir = tmp_path / "input"
 	output_dir = tmp_path / "output"
@@ -67,7 +67,7 @@ def test_trim_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
 	module = load_module("mctutil/transform/trim.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
 	monkeypatch.setattr(module.log, "start", lambda: None)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 
 	input_dir = tmp_path / "input"
 	output_dir = tmp_path / "output"
@@ -87,7 +87,7 @@ def test_normalize_handles_partial_final_batch(load_module, tmp_path, monkeypatc
 	module = load_module("mctutil/transform/normalize.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
 	monkeypatch.setattr(module.log, "start", lambda: None)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 
 	input_dir = tmp_path / "input"
 	output_dir = tmp_path / "output"
@@ -116,7 +116,7 @@ def test_normalize_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
 	module = load_module("mctutil/transform/normalize.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
 	monkeypatch.setattr(module.log, "start", lambda: None)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 
 	input_dir = tmp_path / "input"
 	output_dir = tmp_path / "output"
@@ -141,7 +141,7 @@ def test_normalize_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
 def test_sinogram_preproc_normalizes_small_real_input(load_module, tmp_path, monkeypatch):
 	module = load_module("mctutil/transform/sinogram.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 	monkeypatch.setattr(module, "estimate_sigma", lambda *_args, **_kwargs: 0.0)
 	monkeypatch.setattr(module, "denoise_nl_means", lambda data, **_kwargs: data)
 
@@ -171,7 +171,7 @@ def test_sinogram_preproc_normalizes_small_real_input(load_module, tmp_path, mon
 def test_sinogram_full_mode_normalizes_small_real_input(load_module, tmp_path, monkeypatch):
 	module = load_module("mctutil/transform/sinogram.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 	monkeypatch.setattr(module, "distribute_read", fake_distribute_read)
 
 	input_dir = tmp_path / "input"
@@ -209,7 +209,7 @@ def test_sinogram_full_mode_normalizes_small_real_input(load_module, tmp_path, m
 def test_sinogram_dry_run_writes_nothing(load_module, tmp_path, monkeypatch):
 	module = load_module("mctutil/transform/sinogram.py")
 	monkeypatch.setattr(module, "Pool", SerialPool)
-	monkeypatch.setattr(module.log, "log", lambda *_args, **_kwargs: None)
+	monkeypatch.setattr(module.log, "write", lambda *_args, **_kwargs: None)
 	monkeypatch.setattr(module, "estimate_sigma", lambda *_args, **_kwargs: 0.0)
 	monkeypatch.setattr(module, "denoise_nl_means", lambda data, **_kwargs: data)
 


### PR DESCRIPTION
## Summary

Closes the long-deferred \`shared/log.py\` \`--quiet\` / \`--log-level\` follow-up from REFACTOR_PLAN.md §1.5 / Phase 5. Per the call to align with the lab's other CLI tool (den-sq/lftomo), this ports lftomo's \`Logger\` class wholesale and does the full \`log.log\` -> \`log.write\` rename across all 115 logging sites rather than aliasing for backward compat.

## \`shared/log.py\` rewrite

- **\`DEBUG\` enum -> \`LOG\` IntFlag.** 7 levels at \`0/1/2/4/8/16/32\` (SILENT/ERROR/STATUS/TIME/WARN/INFO/DEBUG). Bitwise filtering replaces the scalar \`__le__\` comparison that was never wired up.
- **\`Logger\` class encapsulates per-destination dispatch.** Two destinations: \`__log_screen\` (\`{stdout, stderr}\` -> LOG mask) and \`__logs\` (named file destinations). Module-level singleton \`log = Logger()\`.
- **Methods:** \`header()\` / \`footer()\` / \`write()\` / \`confirm()\` / \`prompt()\` / \`progress()\` / \`dump()\` / \`set_screen()\` / \`set_threshold()\` / \`set_log_file()\`. \`start()\` is kept as a convenience for header + Script Start.

### Three lftomo bugs fixed in the port

1. **\`~(LOG.INFO or LOG.DEBUG)\` typo** — bitwise \`|\` replaces the short-circuit \`or\` so the default file mask actually combines both flags.
2. **Redundant \`IntFlag.__init__\`** — dropped; colors live in a property dict (\`IntFlag\` already gives \`self.value\`).
3. **Default file-log path allocated at import time** — now lazified via \`set_log_file()\`.

Plus a fourth, fixed for completeness: \`__special_write()\` now writes to both stdout and stderr when both are configured (lftomo's \`elif\` chain skipped stderr if stdout was set).

## CLI plumbing

\`mctutil/cli.py\` gains \`--log-level [quiet|default|verbose|debug]\` on the top-level group, with \`--quiet\` (\`-q\`) and \`--verbose\` (\`-v\`) shorthands. The group callback calls \`log.set_threshold()\` before subcommand dispatch.

## Call-site rename

Across the 115 logging sites:

| Before | After |
|--------|-------|
| \`from mctutil.shared import log\` | \`from mctutil.shared.log import log, LOG\` |
| \`log.log(\"step\", ...)\` | \`log.write(\"step\", ...)\` |
| \`log.DEBUG.STATUS\` (etc.) | \`LOG.STATUS\` (etc.) |
| \`log.log_confirm\` / \`log.log_prompt\` / \`log.log_progress\` | \`log.confirm\` / \`log.prompt\` / \`log.progress\` |
| \`from mctutil.shared.log import log, DEBUG, attach_func\` (in \`shared/mem.py\`) | \`from mctutil.shared.log import log, LOG\`; bare \`log(...)\` calls become \`log.write(...)\`; bare \`attach_func(...)\` becomes \`log.attach_func(...)\` |

## Drive-by

Two files had CRLF line endings (\`mctutil/transport/cv_import.py\`, \`mctutil/ng/point_add.py\`), which made my import-line sed silently skip them. Normalized to LF.

## Test changes

- \`tests/test_phase5_real_behavior.py\`: \`monkeypatch.setattr(module.log, \"log\", ...)\` -> \`monkeypatch.setattr(module.log, \"write\", ...)\` matching the rename. \`module.log.start\` patches still work since \`start()\` is now a method on the Logger instance.
- \`transform/dicom_conv.py\`, \`transform/downsample.py\`, \`transform/transpose.py\` only call \`log.write(...)\` and don't reference \`LOG\` — their import drops the unused \`, LOG\`.
- \`shared/mem.py:97\` line wrapped (was 121 chars after the \`.write\` rename pushed it over the 120-char limit).

## Test plan

- [x] \`flake8 mctutil scripts tests\` clean (no \`--extend-ignore\` needed — fixed every violation CI exposed)
- [x] \`python scripts/check_python_tabs.py\` clean
- [x] \`pytest tests -q\` -> 77 passed
- [x] \`mctutil --help\` shows the new \`--log-level\` / \`--quiet\` / \`--verbose\` options
- [x] End-to-end smoke of \`mctutil [--quiet|--verbose|default] transform decompress-tiff --dry-run /tmp/fixture\`: \`--quiet\` emits nothing on stdout; default emits the STATUS \"N files planned\" line; \`--verbose\` adds the per-file INFO \"Would rewrite\" lines.