### PR TITLE
ci: bump actions to Node 24, fix deprecation warnings

### DIFF
--- a/.github/workflows/phase-0.yml
+++ b/.github/workflows/phase-0.yml
@@ -19,13 +19,14 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           channels: conda-forge
+          conda-remove-defaults: true
           activate-environment: mctutil
-          auto-activate-base: false
+          auto-activate: false
           python-version: ${{ matrix.python-version }}
 
       - name: Install environment


### PR DESCRIPTION
Closes #67.

Two actions on Node 20 bumped to current Node 24 majors:

- \`actions/checkout@v4\` -> \`@v6\`
- \`conda-incubator/setup-miniconda@v3\` -> \`@v4\` (the only breaking change in v4 is the Node 24 runtime bump itself; no input renames affecting this workflow per the v4 release notes)

Drive-by, two other deprecation warnings the same job runs emit:

- \`auto-activate-base: false\` -> \`auto-activate: false\` (the warning explicitly instructed this rename; \`activate-environment: mctutil\` is already set so no additional input needed)
- Added \`conda-remove-defaults: true\` to silence the \"defaults channel might have been added implicitly\" warning. Matches the local-machine channel decision Sorotassu has been running with for the same reasoning (avoid the Anaconda defaults-channel ToS prompt and cut the solver search space).

Test plan: the workflow exercises itself on PR open — if the new actions resolve and the matrix passes on all three Python versions, the bump is good.