### PR TITLE
fix: silence resource_tracker leak warning on mem_tracker import

### DIFF
--- a/mctutil/shared/mem.py
+++ b/mctutil/shared/mem.py
@@ -1,3 +1,4 @@
+import atexit
 from collections import namedtuple
 from multiprocessing import shared_memory
 from sys import stdout
@@ -279,11 +280,35 @@ def __update_last_step(step, pid):
 	last_step[:] = np.frombuffer(step.ljust(20)[:20].encode(), dtype=np.uint8)
 
 
+def _unlink_tracker(name):
+	"""Best-effort unlink by name for the import-time mem_tracker segment.
+
+	`SharedNP.create()` returns a branch and never stores the underlying
+	`shared_memory.SharedMemory` object on the parent — so the parent's
+	close()/unlink() are no-ops. The OS-level segment persists. This
+	helper goes through `shared_memory.SharedMemory(name=...)` directly
+	so the unlink actually releases the segment that resource_tracker
+	is watching, silencing the "leaked shared_memory objects" warning
+	on shutdown.
+	"""
+	try:
+		seg = shared_memory.SharedMemory(name=name)
+		seg.close()
+		seg.unlink()
+	except FileNotFoundError:
+		pass
+
+
 def init_mem_tracker():
 	last_step = SharedNP(dtype=np.uint8, name=f"last_step_{psutil.Process().pid}", shape=NPString(T=20), create=False)
 	with last_step.create() as last_step_arr:
 		last_step_arr[:] = np.frombuffer("Script Inactive     ".encode(), dtype=last_step.dtype)
 	log.attach_func(__update_last_step)
+	# Allocated at module import (any leaf importing shared.mem inherits
+	# it). Without this, every CLI invocation that touches such a leaf —
+	# even `--help` — triggers a `resource_tracker: There appear to be 1
+	# leaked shared_memory objects` warning on shutdown.
+	atexit.register(_unlink_tracker, last_step.name)
 	return last_step
 
 


### PR DESCRIPTION
## Summary

Every CLI invocation that touches a leaf importing \`shared.mem\` — even just \`mctutil transform transpose --help\` — emits:

\`\`\`
UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
\`\`\`

## Root cause

\`shared/mem.py\` allocates a per-process \`mem_tracker\` at module import time (line 290: \`mem_tracker = init_mem_tracker()\`). This creates a \`/dev/shm/last_step_<pid>\` segment via \`shared_memory.SharedMemory(create=True, ...)\` and registers with Python's multiprocessing resource_tracker. Nothing ever unlinks it. The process exits with the segment still registered, so resource_tracker warns on shutdown.

A naive \`atexit.register(cleanup_mem, last_step)\` doesn't fix it: \`SharedNP.create()\` returns a branch SharedNP and never stores the underlying \`shared_memory.SharedMemory\` object on the parent, so the parent's \`close()\` / \`unlink()\` are no-ops.

## Fix

\`init_mem_tracker()\` now registers \`atexit.register(_unlink_tracker, last_step.name)\`. The helper goes through \`shared_memory.SharedMemory(name=...)\` directly so the unlink actually releases the segment that resource_tracker is watching. \`FileNotFoundError\` is swallowed in case the segment was already torn down by another path.

## Why not a deeper fix?

A deeper fix would lazify the import-time allocation so commands that never actually log (like \`--help\`) don't allocate at all. That would restructure the \`log.attach_func(__update_last_step)\` / \`mem_tracker\` coupling — REFACTOR_PLAN.md §5 flags the import-time invariant as load-bearing for the existing logging-to-shm flow. Out of scope here. This PR addresses the symptom cleanly.

## Test plan

Cross-tested every leaf that imports \`shared.mem\`:

| Command | Pre-fix leak warnings | Post-fix |
|---------|------------------------|----------|
| \`mctutil transform transpose --help\` | 1 | 0 |
| \`mctutil transform normalize --help\` | 1 | 0 |
| \`mctutil transform stitch --help\` | 1 | 0 |
| \`mctutil sino convert --help\` | 1 | 0 |
| \`mctutil transform trim --help\` (no shared.mem import) | 0 | 0 |
| \`mctutil transform decompress-tiff --help\` (no shared.mem import) | 0 | 0 |

- [x] \`pytest tests -q\` -> 77 passed
- [x] \`ls /dev/shm/last_step_*\` after \`mctutil transform transpose --help\` -> not found (segment is actually unlinked, not just suppressed)